### PR TITLE
Added LFS support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/rapidjson"]
+	path = vendor/rapidjson
+    url = https://github.com/Tencent/rapidjson

--- a/p4-fusion/CMakeLists.txt
+++ b/p4-fusion/CMakeLists.txt
@@ -7,6 +7,7 @@ endif()
 
 set(OPENSSL_USE_STATIC_LIBS true)
 find_package(OpenSSL)
+find_package(CURL REQUIRED)
 
 add_executable(p4-fusion ${Headers} ${Sources})
 
@@ -14,6 +15,9 @@ target_include_directories(p4-fusion PUBLIC
     ../${HELIX_API}/include/
     ../vendor/libgit2/include/
     ../vendor/minitrace/
+    ../vendor/rapidjson/include/
+    ${OPENSSL_INCLUDE_DIR}
+    ${CURL_INCLUDE_DIRS}
     ${CMAKE_CURRENT_LIST_DIR}
 )
 
@@ -48,6 +52,7 @@ target_link_libraries(p4-fusion PUBLIC
     p4script_cstub
     ${OPENSSL_SSL_LIBRARIES}
     ${OPENSSL_CRYPTO_LIBRARIES}
+    ${CURL_LIBRARIES}
     git2
     minitrace
 )

--- a/p4-fusion/commands/change_list.cc
+++ b/p4-fusion/commands/change_list.cc
@@ -31,7 +31,7 @@ void ChangeList::PrepareDownload(const BranchSet& branchSet)
 {
 	ChangeList& cl = *this;
 
-	ThreadPool::GetSingleton()->AddJob([&cl, &branchSet](P4API* p4)
+	ThreadPool::GetSingleton()->AddJob([&cl, &branchSet](P4API* p4, LFSClient* lfsClient)
 	    {
 		    std::vector<FileData> changedFiles;
 		    if (branchSet.HasMergeableBranch())
@@ -54,15 +54,14 @@ void ChangeList::PrepareDownload(const BranchSet& branchSet)
 
 		    std::unique_lock<std::mutex> lock(*cl.stateMutex);
 		    cl.state = Described;
-		    cl.stateCV->notify_all();
-	    });
+		    cl.stateCV->notify_all(); });
 }
 
-void ChangeList::StartDownload(const int& printBatch)
+void ChangeList::StartDownloadAndLFSUpload(int nPrintBatch)
 {
 	ChangeList& cl = *this;
 
-	ThreadPool::GetSingleton()->AddJob([&cl, printBatch](P4API* p4)
+	ThreadPool::GetSingleton()->AddJob([&cl, nPrintBatch](P4API* p4, LFSClient* lfsClient)
 	    {
 		    // Wait for describe to finish, if it is still running
 		    {
@@ -90,9 +89,9 @@ void ChangeList::StartDownload(const int& printBatch)
 						    printBatchFileData->push_back(&fileData);
 
 						    // Clear the batches if it fits
-						    if (printBatchFiles->size() == printBatch)
+						    if (printBatchFiles->size() == nPrintBatch)
 						    {
-							    cl.Flush(printBatchFiles, printBatchFileData);
+							    cl.DownloadBatch(printBatchFiles, printBatchFileData);
 
 							    // We let go of the refs held by us and create new ones to queue the next batch
 							    printBatchFiles = std::make_shared<std::vector<std::string>>();
@@ -104,25 +103,52 @@ void ChangeList::StartDownload(const int& printBatch)
 			    }
 		    }
 
-		    // Flush any remaining files that were smaller in number than the total batch size.
+		    // Download any remaining files that were smaller in number than the total batch size.
 		    // Additionally, signal the batch processing end.
-		    cl.Flush(printBatchFiles, printBatchFileData);
-	    });
+		    cl.DownloadBatch(printBatchFiles, printBatchFileData); });
 }
 
-void ChangeList::Flush(std::shared_ptr<std::vector<std::string>> printBatchFiles, std::shared_ptr<std::vector<FileData*>> printBatchFileData)
+void ChangeList::DownloadBatch(std::shared_ptr<std::vector<std::string>> printBatchFiles, std::shared_ptr<std::vector<FileData*>> printBatchFileData)
 {
 	// Share ownership of this batch with the thread job
-	ThreadPool::GetSingleton()->AddJob([this, printBatchFiles, printBatchFileData](P4API* p4)
+	ThreadPool::GetSingleton()->AddJob([this, printBatchFiles, printBatchFileData](P4API* p4, LFSClient* lfsClient)
 	    {
 		    // Only perform the batch processing when there are files to process.
 		    if (!printBatchFileData->empty())
 		    {
-			    const PrintResult& printData = p4->PrintFiles(*printBatchFiles);
-
+				const PrintResult& printData = p4->PrintFiles(*printBatchFiles);
 			    for (int i = 0; i < printBatchFiles->size(); i++)
 			    {
-				    printBatchFileData->at(i)->MoveContentsOnceFrom(printData.GetPrintData().at(i).contents);
+					// If in LFS mode, then we determine whether a file is LFS-tracked, and if so, we do produce a ponter file and upload the file contents.
+					if (lfsClient)
+					{
+						if (!lfsClient->IsLFSTracked(printBatchFileData->at(i)->GetRelativePath()))
+						{
+							printBatchFileData->at(i)->MoveContentsOnceFrom(printData.GetPrintData().at(i).contents);
+						} else
+						{
+							const auto& fileContents = printData.GetPrintData().at(i).contents;
+							auto& filePath = printBatchFileData->at(i)->GetRelativePath();
+							const std::vector<char> pointerFileContents = lfsClient->CreatePointerFileContents(fileContents);
+							LFSClient::UploadResult uploadResult = lfsClient->UploadFile(fileContents);
+							switch (uploadResult)
+							{
+								case LFSClient::UploadResult::Uploaded:
+									SUCCESS("Uploaded file " << filePath << " to LFS (" << fileContents.size() << " bytes)");
+									break;
+								case LFSClient::UploadResult::AlreadyExists:
+									SUCCESS("File " << filePath << " already exists in LFS, skipping upload");
+									break;
+								case LFSClient::UploadResult::Error:									
+									ERR("Failed to upload file " << filePath << " to LFS");
+									// Not nice, but we have no other means to signal any intermediate errors from here
+									std::abort();
+							}
+
+							// git blob content should be a pointer file, so replace the contents
+							printBatchFileData->at(i)->MoveContentsOnceFrom(pointerFileContents);
+						}
+					}
 			    }
 		    }
 
@@ -130,17 +156,16 @@ void ChangeList::Flush(std::shared_ptr<std::vector<std::string>> printBatchFiles
 		    filesDownloaded += printBatchFiles->size();
 		    if (filesDownloaded == changedFileGroups->totalFileCount)
 		    {
-			    state = Downloaded;
+			    state = CommitReady;
 			    stateCV->notify_all();
-		    }
-	    });
+		    } });
 }
 
-void ChangeList::WaitForDownload()
+void ChangeList::WaitForBeingCommitReady()
 {
 	std::unique_lock<std::mutex> lock(*stateMutex);
 	stateCV->wait(lock, [this]()
-	    { return state == Downloaded; });
+	    { return state == CommitReady; });
 }
 
 void ChangeList::Clear()

--- a/p4-fusion/commands/change_list.h
+++ b/p4-fusion/commands/change_list.h
@@ -20,7 +20,7 @@ struct ChangeList
 	{
 		Initialized,
 		Described,
-		Downloaded,
+		CommitReady,
 		Freed
 	};
 
@@ -45,9 +45,10 @@ struct ChangeList
 	~ChangeList() = default;
 
 	void PrepareDownload(const BranchSet& branchSet);
-	void StartDownload(const int& printBatch);
-	void Flush(std::shared_ptr<std::vector<std::string>> printBatchFiles, std::shared_ptr<std::vector<FileData*>> printBatchFileData);
-	void WaitForDownload();
+	void StartDownloadAndLFSUpload(int nPrintBatch);
+	void DownloadBatch(std::shared_ptr<std::vector<std::string>> printBatchFiles, std::shared_ptr<std::vector<FileData*>> printBatchFileData);
+
+	void WaitForBeingCommitReady();
 	void Clear();
 
 	friend bool operator==(ChangeList const& cl1, ChangeList const& cl2)

--- a/p4-fusion/git_api.cc
+++ b/p4-fusion/git_api.cc
@@ -6,15 +6,17 @@
  */
 #include "git_api.h"
 
+#include <CoreFoundation/CoreFoundation.h>
+
 #include <cstring>
 #include <cstdlib>
 
 #include "git2.h"
 #include "git2/sys/repository.h"
 #include "minitrace.h"
-#include "utils/std_helpers.h"
 
-#include <CoreFoundation/CoreFoundation.h>
+#include "lfs_client.h"
+#include "utils/std_helpers.h"
 
 namespace
 {
@@ -157,6 +159,34 @@ git_oid GitAPI::CreateBlob(const std::vector<char>& data)
 	return oid;
 }
 
+git_pathspec* GitAPI::CreatePathSpec(const std::vector<std::string>& patterns)
+{
+	git_pathspec* result = nullptr;
+
+	git_strarray strs;
+	strs.count = patterns.size();
+	strs.strings = new char*[strs.count];
+	for (size_t i = 0; i < strs.count; i++)
+	{
+		strs.strings[i] = strdup(patterns[i].c_str());
+	}
+
+	GIT2(git_pathspec_new(&result, &strs));
+
+	for (size_t i = 0; i < strs.count; i++)
+	{
+		free(strs.strings[i]);
+	}
+	delete[] strs.strings;
+
+	return result;
+}
+
+void GitAPI::DestroyPathSpec(git_pathspec* pathSpec)
+{
+	git_pathspec_free(pathSpec);
+}
+
 std::string GitAPI::DetectLatestCL()
 {
 	git_oid oid;
@@ -178,7 +208,7 @@ std::string GitAPI::DetectLatestCL()
 	return cl;
 }
 
-void GitAPI::CreateIndex()
+void GitAPI::CreateIndex(LFSClient* lfsClient)
 {
 	MTR_SCOPE("Git", __func__);
 
@@ -209,12 +239,50 @@ void GitAPI::CreateIndex()
 		git_revwalk_free(walk);
 
 		WARN("Loaded index was refreshed to match the tree of the current HEAD commit");
+
+		// If LFS is enabled, check if the existing repo was initially created with LFS support
+		if (lfsClient)
+		{
+			git_commit* firstCommit = nullptr;
+			GIT2(git_commit_lookup(&firstCommit, m_Repo, &m_FirstCommitOid));
+
+			git_tree* tree = nullptr;
+			GIT2(git_commit_tree(&tree, firstCommit));
+
+			git_tree_entry* entry = nullptr;
+			int errorCode = git_tree_entry_bypath(&entry, tree, ".gitattributes");
+			if (errorCode == GIT_ENOTFOUND)
+			{
+				ERR("GitAPI: LFS support was requested, but existing repo was not created with it!");
+
+				git_tree_free(tree);
+				git_commit_free(firstCommit);
+
+				exit(errorCode);
+			}
+			else if (errorCode != 0)
+			{
+				GIT2(errorCode);
+			}
+
+			git_tree_entry_free(entry);
+			git_tree_free(tree);
+			git_commit_free(firstCommit);
+		}
 	}
 	else
 	{
-		// In order to have branches be mergable, even with no shared history, we perform
-		// a trick by adding an empty commit as the very first commit, and use this as the base for all branches.
-		// The time is set to the beginning of time.
+		// Add .gitattributes file if LFS is enabled
+		if (lfsClient)
+		{
+			auto gitAttrContents = lfsClient->GetGitAttributesContents();
+			git_index_entry entry = {};
+			entry.mode = GIT_FILEMODE_BLOB;
+			entry.path = ".gitattributes";
+			GIT2(git_index_add_from_buffer(m_Index, &entry, gitAttrContents.data(), gitAttrContents.size()));
+		}
+
+		// Create initial commit
 		git_oid commitTreeID;
 		GIT2(git_index_write_tree_to(&commitTreeID, m_Index, m_Repo));
 

--- a/p4-fusion/git_api.h
+++ b/p4-fusion/git_api.h
@@ -11,9 +11,12 @@
 #include <utility>
 
 #include "common.h"
+
 #include "git2/oid.h"
+#include "git2/pathspec.h"
 
 struct git_repository;
+class LFSClient;
 
 class GitAPI
 {
@@ -36,7 +39,10 @@ public:
 
 	git_oid CreateBlob(const std::vector<char>& data);
 
-	void CreateIndex();
+	git_pathspec* CreatePathSpec(const std::vector<std::string>& patterns);
+	void DestroyPathSpec(git_pathspec* pathSpec);
+
+	void CreateIndex(LFSClient* lfsClient);
 	void SetActiveBranch(const std::string& branchName);
 	void AddFileToIndex(const std::string& relativePath, const std::vector<char>& contents, const bool plusx);
 	void RemoveFileFromIndex(const std::string& relativePath);

--- a/p4-fusion/lfs_client.cc
+++ b/p4-fusion/lfs_client.cc
@@ -1,0 +1,492 @@
+/*
+ * Copyright (c) 2022 Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+#include "lfs_client.h"
+
+#include "openssl/sha.h"
+#include <curl/curl.h>
+#include <memory>
+#include <sstream>
+#include <cstdlib>
+#include <thread>
+#include <chrono>
+#include <functional>
+#include "rapidjson/document.h"
+#include "rapidjson/writer.h"
+#include "rapidjson/stringbuffer.h"
+
+namespace
+{
+
+// Retry configuration
+const int MaxRetryAttempts = 3;
+const int InitialRetryDelayMs = 1000;
+
+bool ShouldRetryRequest(CURLcode curl_result, long response_code)
+{
+	if (curl_result != CURLE_OK)
+	{
+		switch (curl_result)
+		{
+		case CURLE_COULDNT_CONNECT:
+		case CURLE_COULDNT_RESOLVE_HOST:
+		case CURLE_COULDNT_RESOLVE_PROXY:
+		case CURLE_OPERATION_TIMEDOUT:
+		case CURLE_RECV_ERROR:
+		case CURLE_SEND_ERROR:
+		case CURLE_GOT_NOTHING:
+		case CURLE_PARTIAL_FILE:
+			return true;
+		default:
+			return false;
+		}
+	}
+
+	return (response_code < 200 || response_code >= 300);
+}
+
+struct RequestResult
+{
+	CURLcode curl_result;
+	long response_code;
+	std::string response_body;
+};
+
+// Helper function to perform HTTP requests with retry logic
+RequestResult PerformRequestWithRetry(std::function<RequestResult()> requestFunc)
+{
+	RequestResult result;
+
+	for (size_t attempt = 0; attempt < MaxRetryAttempts; ++attempt)
+	{
+		result = requestFunc();
+
+		if (!ShouldRetryRequest(result.curl_result, result.response_code))
+		{
+			break;
+		}
+
+		if (result.curl_result != CURLE_OK)
+		{
+			WARN("LFS request failed with curl error " << result.curl_result << ", retrying (attempt " << (attempt + 1) << "/" << MaxRetryAttempts << ")");
+		}
+		else
+		{
+			WARN("LFS request failed with HTTP status " << result.response_code << ", retrying (attempt " << (attempt + 1) << "/" << MaxRetryAttempts << ")");
+		}
+
+		if (attempt < MaxRetryAttempts - 1)
+		{
+			int delay_ms = InitialRetryDelayMs * (1 << attempt);
+			std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
+		}
+	}
+
+	return result;
+}
+
+class CURLHandle
+{
+public:
+	CURLHandle()
+	{
+		curl = curl_easy_init();
+		if (!curl)
+		{
+			throw std::runtime_error("Failed to initialize CURL");
+		}
+	}
+
+	~CURLHandle()
+	{
+		if (curl)
+		{
+			curl_easy_cleanup(curl);
+		}
+	}
+
+	CURL* get() const { return curl; }
+	explicit operator bool() const { return curl != nullptr; }
+
+private:
+	CURL* curl;
+};
+
+// Callback function to write response data
+static size_t WriteCallback(void* contents, size_t size, size_t nmemb, std::string* userp)
+{
+	size_t totalSize = size * nmemb;
+	userp->append(static_cast<char*>(contents), totalSize);
+	return totalSize;
+}
+
+void SetupBasicAuth(CURL* curl, const std::string& username, const std::string& password)
+{
+	if (!username.empty() && !password.empty())
+	{
+		curl_easy_setopt(curl, CURLOPT_HTTPAUTH, (long)CURLAUTH_BASIC);
+		curl_easy_setopt(curl, CURLOPT_USERNAME, username.c_str());
+		curl_easy_setopt(curl, CURLOPT_PASSWORD, password.c_str());
+	}
+}
+
+void SetupRequest(CURL* curl,
+    const std::string& url,
+    const void* data,
+    size_t data_size,
+    struct curl_slist* headers,
+    RequestResult* pResult,
+    const std::string& username = "",
+    const std::string& password = "")
+{
+	SetupBasicAuth(curl, username, password);
+
+	curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+	curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data);
+	curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, data_size);
+	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
+	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &pResult->response_body);
+	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+}
+
+RequestResult PerformPostRequestWithRetry(CURL* curl,
+    const std::string& url,
+    const void* data,
+    size_t data_size,
+    struct curl_slist* headers,
+    const std::string& username = "",
+    const std::string& password = "")
+{
+	RequestResult result = {};
+	SetupRequest(curl, url, data, data_size, headers, &result, username, password);
+
+	return PerformRequestWithRetry([&]() -> RequestResult
+	    {        
+        result.curl_result = curl_easy_perform(curl);
+        
+        if (result.curl_result == CURLE_OK) {
+            curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &result.response_code);
+        }
+        
+        return result; });
+}
+
+// Helper function to perform a PUT request with binary data
+RequestResult PerformPutRequestWithRetry(CURL* curl, const std::string& url,
+    const void* data, size_t data_size,
+    struct curl_slist* headers,
+    const std::string& username = "",
+    const std::string& password = "")
+{
+	RequestResult result = {};
+	SetupRequest(curl, url, data, data_size, headers, &result, username, password);
+
+	curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
+
+	return PerformRequestWithRetry([&]() -> RequestResult
+	    {
+        result.curl_result = curl_easy_perform(curl);
+        
+        if (result.curl_result == CURLE_OK) {
+            curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &result.response_code);
+        }
+        
+        return result; });
+}
+
+struct BatchResponse
+{
+	bool success = false;
+	std::string uploadUrl;
+	std::string verifyUrl;
+	bool needsUpload = false;
+};
+
+std::string CreateBatchUploadPayload(const std::string& oid, size_t fileSize)
+{
+	rapidjson::Document doc;
+	doc.SetObject();
+	rapidjson::Document::AllocatorType& allocator = doc.GetAllocator();
+
+	doc.AddMember("operation", "upload", allocator);
+
+	rapidjson::Value transfers(rapidjson::kArrayType);
+	transfers.PushBack("basic", allocator);
+	doc.AddMember("transfers", transfers, allocator);
+
+	rapidjson::Value objects(rapidjson::kArrayType);
+	rapidjson::Value obj(rapidjson::kObjectType);
+	obj.AddMember("oid", rapidjson::StringRef(oid.c_str()), allocator);
+	obj.AddMember("size", static_cast<uint64_t>(fileSize), allocator);
+	objects.PushBack(obj, allocator);
+	doc.AddMember("objects", objects, allocator);
+
+	rapidjson::StringBuffer buffer;
+	rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+	doc.Accept(writer);
+	return buffer.GetString();
+}
+
+BatchResponse PerformBatchUploadRequest(const std::string& serverUrl, const std::string& username, const std::string& password, const std::string& oid, size_t fileSize)
+{
+	BatchResponse result;
+
+	const std::string payload = CreateBatchUploadPayload(oid, fileSize);
+
+	CURLHandle curl;
+	if (!curl)
+	{
+		return result;
+	}
+
+	struct curl_slist* headers = nullptr;
+	headers = curl_slist_append(headers, "Content-Type: application/vnd.git-lfs+json");
+	headers = curl_slist_append(headers, "Accept: application/vnd.git-lfs+json");
+
+	std::string batchUrl = serverUrl + "/objects/batch";
+	auto batchResult = PerformPostRequestWithRetry(curl.get(), batchUrl, payload.data(), payload.size(), headers, username, password);
+	curl_slist_free_all(headers);
+
+	if (batchResult.curl_result != CURLE_OK || batchResult.response_code != 200)
+	{
+		return result;
+	}
+
+	// Parse response using rapidjson
+	rapidjson::Document responseDoc;
+	if (responseDoc.Parse(batchResult.response_body.c_str()).HasParseError())
+	{
+		return result;
+	}
+
+	// Check if objects array exists and has our object
+	if (!responseDoc.HasMember("objects") || !responseDoc["objects"].IsArray() || responseDoc["objects"].Size() == 0)
+	{
+		return result;
+	}
+
+	const rapidjson::Value& objectsArray = responseDoc["objects"];
+	const rapidjson::Value& firstObject = objectsArray[0];
+
+	// Check if upload action is needed
+	if (!firstObject.HasMember("actions") || !firstObject["actions"].IsObject())
+	{
+		// No actions means file already exists
+		result.success = true;
+		result.needsUpload = false;
+		return result;
+	}
+
+	const rapidjson::Value& actions = firstObject["actions"];
+	if (!actions.HasMember("upload") || !actions["upload"].IsObject())
+	{
+		// No upload action means file already exists
+		result.success = true;
+		result.needsUpload = false;
+		return result;
+	}
+
+	// Extract upload URL from response
+	const rapidjson::Value& uploadAction = actions["upload"];
+	if (!uploadAction.HasMember("href") || !uploadAction["href"].IsString())
+	{
+		return result;
+	}
+
+	result.uploadUrl = uploadAction["href"].GetString();
+	result.needsUpload = true;
+
+	// Check if verification is required
+	if (actions.HasMember("verify") && actions["verify"].IsObject())
+	{
+		const rapidjson::Value& verifyAction = actions["verify"];
+		if (verifyAction.HasMember("href") && verifyAction["href"].IsString())
+		{
+			result.verifyUrl = verifyAction["href"].GetString();
+		}
+	}
+
+	result.success = true;
+	return result;
+}
+
+LFSClient::UploadResult PerformUpload(const std::string& username, const std::string& password, const std::string& uploadUrl, const std::vector<char>& fileContents)
+{
+	// Initialize curl
+	CURLHandle curl;
+	if (!curl)
+	{
+		return LFSClient::UploadResult::Error;
+	}
+
+	// Set up headers for file upload
+	struct curl_slist* uploadHeaders = nullptr;
+	uploadHeaders = curl_slist_append(uploadHeaders, "Content-Type: application/octet-stream");
+	uploadHeaders = curl_slist_append(uploadHeaders, "Accept: application/vnd.git-lfs");
+
+	auto uploadResult = PerformPutRequestWithRetry(curl.get(), uploadUrl, fileContents.data(),
+	    fileContents.size(), uploadHeaders, username, password);
+	curl_slist_free_all(uploadHeaders);
+
+	if (uploadResult.curl_result != CURLE_OK)
+	{
+		return LFSClient::UploadResult::Error;
+	}
+
+	if (uploadResult.response_code >= 200 && uploadResult.response_code < 300)
+	{
+		return LFSClient::UploadResult::Uploaded;
+	}
+
+	return LFSClient::UploadResult::Error;
+}
+
+std::string CreateVerifyPayload(const std::string& oid, size_t fileSize)
+{
+	rapidjson::Document verifyDoc;
+	verifyDoc.SetObject();
+	rapidjson::Document::AllocatorType& verifyAllocator = verifyDoc.GetAllocator();
+	verifyDoc.AddMember("oid", rapidjson::StringRef(oid.c_str()), verifyAllocator);
+	verifyDoc.AddMember("size", static_cast<uint64_t>(fileSize), verifyAllocator);
+
+	rapidjson::StringBuffer verifyBuffer;
+	rapidjson::Writer<rapidjson::StringBuffer> verifyWriter(verifyBuffer);
+	verifyDoc.Accept(verifyWriter);
+
+	return verifyBuffer.GetString();
+}
+
+bool PerformVerify(const std::string& username, const std::string& password, const std::string& verifyUrl, const std::string& oid, size_t fileSize)
+{
+	CURLHandle curl;
+	if (!curl)
+	{
+		return false;
+	}
+
+	rapidjson::Document verifyDoc;
+	verifyDoc.SetObject();
+	rapidjson::Document::AllocatorType& verifyAllocator = verifyDoc.GetAllocator();
+	verifyDoc.AddMember("oid", rapidjson::StringRef(oid.c_str()), verifyAllocator);
+	verifyDoc.AddMember("size", static_cast<uint64_t>(fileSize), verifyAllocator);
+
+	rapidjson::StringBuffer verifyBuffer;
+	rapidjson::Writer<rapidjson::StringBuffer> verifyWriter(verifyBuffer);
+	verifyDoc.Accept(verifyWriter);
+	std::string verifyPayload = verifyBuffer.GetString();
+
+	struct curl_slist* verifyHeaders = nullptr;
+	verifyHeaders = curl_slist_append(verifyHeaders, "Content-Type: application/vnd.git-lfs+json");
+	verifyHeaders = curl_slist_append(verifyHeaders, "Accept: application/vnd.git-lfs+json");
+
+	auto verifyResult = PerformPostRequestWithRetry(curl.get(),
+	    verifyUrl, verifyPayload.data(),
+	    verifyPayload.size(),
+	    verifyHeaders,
+	    username,
+	    password);
+	curl_slist_free_all(verifyHeaders);
+
+	return (verifyResult.curl_result == CURLE_OK && verifyResult.response_code == 200);
+}
+
+}
+
+LFSClient::LFSClient(GitAPI& gitAPI, const std::string& serverUrl, const std::string& username, const std::string& password, const std::vector<std::string>& lfsPatterns)
+    : m_GitAPI(gitAPI)
+    , m_ServerUrl(serverUrl)
+    , m_Username(username)
+    , m_Password(password)
+    , m_LFSPatterns(lfsPatterns)
+{
+	m_LFSPathSpec = m_GitAPI.CreatePathSpec(lfsPatterns);
+}
+
+std::vector<char> LFSClient::CreatePointerFileContents(const std::vector<char>& fileContents) const
+{
+	unsigned char hash[SHA256_DIGEST_LENGTH];
+	SHA256(reinterpret_cast<const unsigned char*>(fileContents.data()), fileContents.size(), hash);
+
+	std::string hexHash;
+	for (int i = 0; i < SHA256_DIGEST_LENGTH; i++)
+	{
+		char hex[3];
+		snprintf(hex, sizeof(hex), "%02x", hash[i]);
+		hexHash += hex;
+	}
+
+	std::string pointerContent = "version https://git-lfs.github.com/spec/v1\n"
+	                             "oid sha256:"
+	    + hexHash + "\n"
+	                "size "
+	    + std::to_string(fileContents.size()) + "\n";
+
+	return std::vector<char>(pointerContent.begin(), pointerContent.end());
+}
+
+LFSClient::UploadResult LFSClient::UploadFile(const std::vector<char>& fileContents) const
+{
+	unsigned char hash[SHA256_DIGEST_LENGTH];
+	SHA256(reinterpret_cast<const unsigned char*>(fileContents.data()), fileContents.size(), hash);
+
+	std::string oid;
+	for (int i = 0; i < SHA256_DIGEST_LENGTH; i++)
+	{
+		char hex[3];
+		snprintf(hex, sizeof(hex), "%02x", hash[i]);
+		oid += hex;
+	}
+
+	auto batchResponse = PerformBatchUploadRequest(m_ServerUrl, m_Username, m_Password, oid, fileContents.size());
+	if (!batchResponse.success)
+	{
+		return UploadResult::Error;
+	}
+
+	if (!batchResponse.needsUpload)
+	{
+		return UploadResult::AlreadyExists;
+	}
+
+	auto uploadResult = PerformUpload(m_Username, m_Password, batchResponse.uploadUrl, fileContents);
+	if (uploadResult != UploadResult::Uploaded)
+	{
+		return uploadResult;
+	}
+
+	if (!batchResponse.verifyUrl.empty())
+	{
+		if (!PerformVerify(m_Username, m_Password, batchResponse.verifyUrl, oid, fileContents.size()))
+		{
+			return UploadResult::Error;
+		}
+	}
+
+	return UploadResult::Uploaded;
+}
+
+bool LFSClient::IsLFSTracked(const std::string& filePath) const
+{
+	return git_pathspec_matches_path(m_LFSPathSpec, GIT_PATHSPEC_IGNORE_CASE, filePath.c_str()) == 1;
+}
+
+std::vector<char> LFSClient::GetGitAttributesContents() const
+{
+	std::vector<char> result;
+	for (const auto& pattern : m_LFSPatterns)
+	{
+		const std::string line = pattern + " filter=lfs diff=lfs merge=lfs -text\n";
+		result.insert(result.end(), line.begin(), line.end());
+	}
+
+	return result;
+}
+
+LFSClient::~LFSClient()
+{
+	m_GitAPI.DestroyPathSpec(m_LFSPathSpec);
+}

--- a/p4-fusion/lfs_client.h
+++ b/p4-fusion/lfs_client.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "git2/pathspec.h"
+
+#include "git_api.h"
+
+// Thread-safe class for handling Git LFS (Large File Storage) operations
+class LFSClient
+{
+public:
+	enum class UploadResult
+	{
+		Uploaded,
+		AlreadyExists,
+		Error
+	};
+
+	LFSClient(GitAPI& gitAPI, const std::string& serverUrl, const std::string& username, const std::string& password, const std::vector<std::string>& lfsPatterns);
+	~LFSClient();
+
+	std::vector<char> CreatePointerFileContents(const std::vector<char>& fileContents) const;
+
+	UploadResult UploadFile(const std::vector<char>& fileContents) const;
+
+	bool IsLFSTracked(const std::string& filePath) const;
+
+	std::vector<char> GetGitAttributesContents() const;
+
+private:
+	GitAPI& m_GitAPI;
+
+	const std::string m_ServerUrl;
+	const std::string m_Username;
+	const std::string m_Password;
+
+	std::vector<std::string> m_LFSPatterns;
+	git_pathspec* m_LFSPathSpec;
+};

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -16,6 +16,7 @@
 #include <typeinfo>
 #include <csignal>
 #include <iterator>
+#include <fstream>
 
 #include "common.h"
 
@@ -27,6 +28,7 @@
 #include "p4_api.h"
 #include "git_api.h"
 #include "branch_set.h"
+#include "lfs_client.h"
 
 #include "p4/p4libs.h"
 #include "minitrace.h"
@@ -59,6 +61,10 @@ int Main(int argc, char** argv)
 	Arguments::GetSingleton()->OptionalParameterList("--exclude", "A regex used to exclude files from the conversion. Can be specified more than once.");
 	Arguments::GetSingleton()->OptionalParameter("--excludeLogPath", "", "Path to a file where the excluded files will be logged.");
 	Arguments::GetSingleton()->OptionalParameter("--streamMappings", "false", "Use Mappings defined by Perforce Stream Spec for a given stream");
+	Arguments::GetSingleton()->OptionalParameter("--lfsSpecPath", "", "File path containings path specs for files to be handled by Git LFS.");
+	Arguments::GetSingleton()->OptionalParameter("--lfsServerUrl", "", "URL of the Git LFS server to use for uploading files with basic transfer.");
+	Arguments::GetSingleton()->OptionalParameter("--lfsUsername", "", "Git LFS username for basic access authentication.");
+	Arguments::GetSingleton()->OptionalParameter("--lfsPassword", "", "Git LFS password for basic access authentication.");
 
 	PRINT("p4-fusion " P4_FUSION_VERSION);
 
@@ -102,6 +108,42 @@ int Main(int argc, char** argv)
 		}
 	}
 	const bool streamMappings = Arguments::GetSingleton()->GetStreamMappings() != "false";
+
+	const std::string lfsSpecPath = Arguments::GetSingleton()->GetLFSSpecPath();
+	const std::string lfsServerUrl = Arguments::GetSingleton()->GetLFSServerUrl();
+	const std::string lfsUsername = Arguments::GetSingleton()->GetLFSUsername();
+	const std::string lfsPassword = Arguments::GetSingleton()->GetLFSPassword();
+
+	GitAPI git(fsyncEnable);
+	std::unique_ptr<LFSClient> lfsClient;
+	if (!lfsSpecPath.empty() && !lfsServerUrl.empty())
+	{
+		std::vector<std::string> lfsPatterns;
+		std::ifstream lfsFile(lfsSpecPath);
+		if (!lfsFile.is_open())
+		{
+			ERR("Failed to open LFS spec file: " << lfsSpecPath);
+			return 1;
+		}
+		std::string line;
+		while (std::getline(lfsFile, line))
+		{
+			// Ignore empty lines and comments
+			if (!line.empty() && line[0] != '#')
+			{
+				lfsPatterns.push_back(line);
+			}
+		}
+		lfsFile.close();
+
+		lfsClient.reset(new LFSClient(git, lfsServerUrl, lfsUsername, lfsPassword, lfsPatterns));
+		PRINT("Initialized LFS client with server URL: " << lfsServerUrl);
+
+		if (!includeBinaries)
+		{
+			WARN("LFS support is enabled, but binaries are excluded. This is probably not what you want.");
+		}
+	}
 
 	PRINT("Running p4-fusion from: " << argv[0]);
 
@@ -276,8 +318,6 @@ int Main(int argc, char** argv)
 		PRINT("Excluded paths: " << exclusions.size());
 	}
 
-	GitAPI git(fsyncEnable);
-
 	if (!git.InitializeRepository(srcPath))
 	{
 		ERR("Could not initialize Git repository. Exiting.");
@@ -336,7 +376,7 @@ int Main(int argc, char** argv)
 	SUCCESS("Found " << changes.size() << " uncloned CLs starting from CL " << changes.front().number << " to CL " << changes.back().number);
 
 	PRINT("Creating " << networkThreads << " network threads");
-	ThreadPool::GetSingleton()->Initialize(networkThreads);
+	ThreadPool::GetSingleton()->Initialize(networkThreads, lfsClient.get());
 	SUCCESS("Created " << ThreadPool::GetSingleton()->GetThreadCount() << " threads in thread pool");
 
 	int startupDownloadsCount = 0;
@@ -360,10 +400,11 @@ int Main(int argc, char** argv)
 	{
 		ChangeList& cl = changes.at(currentCL);
 
-		// Start running `p4 print` on changed files when the describe is finished
-		cl.StartDownload(printBatch);
+		// Start running `p4 print` on changed files when the describe is finished. Upload LFS files if needed.
+		cl.StartDownloadAndLFSUpload(printBatch);
 	}
 
+	git.CreateIndex(lfsClient.get());
 	SUCCESS("Queued first " << startupDownloadsCount << " CLs up until CL " << changes.at(lastDownloadedCL).number << " for downloading");
 
 	int timezoneMinutes = p4.Info().GetServerTimezoneMinutes();
@@ -378,7 +419,6 @@ int Main(int argc, char** argv)
 
 	PRINT("Last CL to start downloading is CL " << changes.at(lastDownloadedCL).number);
 
-	git.CreateIndex();
 	for (size_t i = 0; i < changes.size(); i++)
 	{
 		// See if the threadpool encountered any exceptions
@@ -396,8 +436,7 @@ int Main(int argc, char** argv)
 
 		ChangeList& cl = changes.at(i);
 
-		// Ensure the files are downloaded before committing them to the repository
-		cl.WaitForDownload();
+		cl.WaitForBeingCommitReady();
 
 		std::string fullName = cl.user;
 		std::string email = "deleted@user";
@@ -474,7 +513,7 @@ int Main(int argc, char** argv)
 			lastDownloadedCL++;
 			ChangeList& downloadCL = changes.at(lastDownloadedCL);
 			downloadCL.PrepareDownload(branchSet);
-			downloadCL.StartDownload(printBatch);
+			downloadCL.StartDownloadAndLFSUpload(printBatch);
 		}
 
 		// Occasionally flush the profiling data

--- a/p4-fusion/thread_pool.cc
+++ b/p4-fusion/thread_pool.cc
@@ -83,16 +83,17 @@ void ThreadPool::ShutDown()
 void ThreadPool::Resize(int size)
 {
 	ShutDown();
-	Initialize(size);
+	Initialize(size, m_LFSClient);
 }
 
-void ThreadPool::Initialize(int size)
+void ThreadPool::Initialize(int size, LFSClient* lfsClient)
 {
 	m_HasShutDownBeenCalled = false;
 	m_ShouldStop = false;
 	m_JobsProcessing = 0;
 
 	m_P4Contexts.resize(size);
+	m_LFSClient = lfsClient;
 
 	for (int i = 0; i < size; i++)
 	{
@@ -124,7 +125,7 @@ void ThreadPool::Initialize(int size)
 
 				    try
 				    {
-					    job(localP4);
+					    job(localP4, m_LFSClient);
 				    }
 				    catch (const std::exception& e)
 				    {
@@ -133,8 +134,7 @@ void ThreadPool::Initialize(int size)
 					    m_ThreadExceptions[i] = std::current_exception();
 				    }
 				    m_JobsProcessing--;
-			    }
-		    }));
+			    } }));
 	}
 }
 

--- a/p4-fusion/thread_pool.h
+++ b/p4-fusion/thread_pool.h
@@ -13,18 +13,20 @@
 #include <condition_variable>
 
 #include "common.h"
+#include "lfs_client.h"
 
 class P4API;
 
 class ThreadPool
 {
-	typedef std::function<void(P4API*)> Job;
+	typedef std::function<void(P4API*, LFSClient*)> Job;
 
 	std::vector<std::thread> m_Threads;
 	std::mutex m_ThreadExceptionsMutex;
 	std::vector<std::exception_ptr> m_ThreadExceptions;
 	std::vector<std::string> m_ThreadNames;
 	std::vector<P4API> m_P4Contexts;
+	LFSClient* m_LFSClient;
 
 	std::deque<Job> m_Jobs;
 	std::mutex m_JobsMutex;
@@ -41,7 +43,7 @@ public:
 
 	~ThreadPool();
 
-	void Initialize(int size);
+	void Initialize(int size, LFSClient* lfsClient);
 	void AddJob(Job function);
 	void Wait();
 	void RaiseCaughtExceptions();

--- a/p4-fusion/utils/arguments.cc
+++ b/p4-fusion/utils/arguments.cc
@@ -65,6 +65,12 @@ bool Arguments::IsValid() const
 			return false;
 		}
 	}
+
+	const bool hasAnyLFSParam = !GetLFSSpecPath().empty() || !GetLFSServerUrl().empty() || !GetLFSUsername().empty() || !GetLFSPassword().empty();
+	const bool hasAllLFSParams = !GetLFSSpecPath().empty() && !GetLFSServerUrl().empty();
+	if (hasAnyLFSParam && !hasAllLFSParams)
+		return false;
+
 	return true;
 }
 

--- a/p4-fusion/utils/arguments.h
+++ b/p4-fusion/utils/arguments.h
@@ -60,4 +60,8 @@ public:
 	std::vector<std::string> GetBranches() const { return GetParameterList("--branch"); };
 	std::vector<std::string> GetExcludes() const { return GetParameterList("--exclude"); };
 	std::string GetExcludeLogPath() const { return GetParameter("--excludeLogPath"); };
+	std::string GetLFSSpecPath() const { return GetParameter("--lfsSpecPath"); }
+	std::string GetLFSServerUrl() const { return GetParameter("--lfsServerUrl"); }
+	std::string GetLFSUsername() const { return GetParameter("--lfsUsername"); }
+	std::string GetLFSPassword() const { return GetParameter("--lfsPassword"); }
 };


### PR DESCRIPTION
### Why

[LFS](https://git-lfs.com/) is currently the most mature and well-known technology for storing binary files with git. This PR adds LFS support to this conversion tool, so Perforce codebases containing binary files can be converted into ready-to-use git repos.

### What
* LFS support was added, which is optional to use
* Uploads are carried out using the so-called [basic transfer API ](https://github.com/git-lfs/git-lfs/blob/main/docs/api/basic-transfers.md)
* Basic authentication is supported (most LFS implementations support this, in one way or another)
* Even if LFS support is used, the conversion process is fully interruptible and resumable

### How
An alternative to adding LFS support could be to:
* convert with `--includeBinaries`, so even binary files are committed to the resulting git repo "as-is"
* after the conversion, run [git lfs migrate](https://github.com/git-lfs/git-lfs/blob/main/docs/man/git-lfs-migrate.adoc?utm_source=gitlfs_site&utm_medium=doc_man_migrate_link&utm_campaign=gitlfs)

This, however would have serious downsides:
* every file will be present on your local storage device (e.g. if you have a 100 GiBs of files in P4, then after your conversion, you will have a git repo of ~100 GiBs)
* manual steps are involved (running `git lfs migrate`) after conversion

In a nutshell, here's how LFS support was implemented:
* If LFS support is requested via the command line parameters, we prepare an object instance of `LFSClient` to be used in the conversion process, otherwise everything runs as before
* A text file must be passed which contains lines of patterns in [pathspec](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-pathspec) form, this is how the tool decides whether a file will be LFS-tracked or not
  * This gets converted to a `.gitattributes` file, and will be the content of the first commit (which is usually empty). This ensures that the repo will be `clone`able at any given commit.
    * An alternative could be to dynamically keep track of the necessary "patterns" (e.g. specify what files you want in LFS by size), but that would have been way too complex to implement
* The step of downloading the files from Perforce was modified to also upload LFS-tracked files, if any.
  * This is an important design consideration. This means that a changelist is not committed unless all LFS-tracked files are uploaded. Since a commit contains only [pointer file](https://github.com/git-lfs/git-lfs/blob/main/docs/man/git-lfs-pointer.adoc)s for LFS-tracked files, we could perform the commit, and _then_ upload LFS-files asynchronosly. This, however, would make it impossible to make the conversion interruptible and resumable (consider: a commit is performed, but one or more LFS uploads fail)
* Even for LFS-tracked files, we download them into memory, from this aspect there is no difference between "regular" and LFS-tracked files

I tested this feature with 3 different LFS server implementations:
* [lfs-test-server](https://github.com/git-lfs/lfs-test-server)
* [rudolfs](https://github.com/jasonwhite/rudolfs)
* [giftless](https://github.com/datopian/giftless)

Everything worked correctly, except in the case of `lfs-test-server`, where there seems to be a server-side race condition if parallel uploads are taking place. I'm working on a minimal repro to rule out bugs in this PR.