### PR TITLE
Shorten commit message

### DIFF
--- a/p4-fusion/git_api.cc
+++ b/p4-fusion/git_api.cc
@@ -364,7 +364,7 @@ std::string GitAPI::Commit(
 	GIT2(git_signature_new(&author, user.c_str(), email.c_str(), timestamp, timezone));
 
 	// -3 to remove the trailing "..."
-	std::string commitMsg = cl + " - " + desc + "\n[p4-fusion: depot-paths = \"" + depotPath.substr(0, depotPath.size() - 3) + "\": change = " + cl + "]";
+	std::string commitMsg = desc + "\n[p4-fusion: depot-paths = \"" + depotPath.substr(0, depotPath.size() - 3) + "\": change = " + cl + "]";
 
 	// Find the parent commits.
 	// Order is very important.


### PR DESCRIPTION
Since in the BIMx repo almost all changelist descriptions already start with the Jira issue key, I think if the resulting Git commits are further prefixed with the p4 changelist number, it ends up being too much visual clutter when one is looking at history. The changelist number is also present in the added suffix so we are not losing information.