### PR TITLE
Handle P4 special characters (BIMX-17708 / BIMX-17789)

### DIFF
--- a/p4-fusion/branch_set.cc
+++ b/p4-fusion/branch_set.cc
@@ -10,16 +10,6 @@
 static const std::string EMPTY_STRING = "";
 static const std::array<std::string, 2> INVALID_BRANCH_PATH { EMPTY_STRING, EMPTY_STRING };
 
-std::vector<std::string> BranchedFileGroup::GetRelativeFileNames()
-{
-	std::vector<std::string> ret;
-	for (auto& fileData : files)
-	{
-		ret.push_back(fileData.GetRelativePath());
-	}
-	return ret;
-}
-
 ChangedFileGroups::ChangedFileGroups()
     : totalFileCount(0)
 {
@@ -348,7 +338,7 @@ std::unique_ptr<ChangedFileGroups> BranchSet::ParseAffectedFiles(const std::vect
 
 			// It's a valid destination to a branch.
 			// Make sure the relative path is set.
-			fileData.SetRelativePath(branchPath[1]);
+			fileData.SetRelativePathForGit(branchPath[1]);
 
 			bool needsHandling = true;
 			if (fileData.IsIntegrated())
@@ -379,7 +369,7 @@ std::unique_ptr<ChangedFileGroups> BranchSet::ParseAffectedFiles(const std::vect
 		{
 			// It's a non-branching setup.
 			// Make sure the relative path is set.
-			fileData.SetRelativePath(relativeDepotPath);
+			fileData.SetRelativePathForGit(relativeDepotPath);
 			branchMap.addTarget(EMPTY_STRING, fileData);
 		}
 	}

--- a/p4-fusion/branch_set.cc
+++ b/p4-fusion/branch_set.cc
@@ -338,7 +338,7 @@ std::unique_ptr<ChangedFileGroups> BranchSet::ParseAffectedFiles(const std::vect
 
 			// It's a valid destination to a branch.
 			// Make sure the relative path is set.
-			fileData.SetRelativePathForGit(branchPath[1]);
+			fileData.SetRelativeDepotPath(branchPath[1]);
 
 			bool needsHandling = true;
 			if (fileData.IsIntegrated())
@@ -369,7 +369,7 @@ std::unique_ptr<ChangedFileGroups> BranchSet::ParseAffectedFiles(const std::vect
 		{
 			// It's a non-branching setup.
 			// Make sure the relative path is set.
-			fileData.SetRelativePathForGit(relativeDepotPath);
+			fileData.SetRelativeDepotPath(relativeDepotPath);
 			branchMap.addTarget(EMPTY_STRING, fileData);
 		}
 	}

--- a/p4-fusion/branch_set.h
+++ b/p4-fusion/branch_set.h
@@ -30,9 +30,6 @@ struct BranchedFileGroup
 	std::string targetBranch;
 	bool hasSource;
 	std::vector<FileData> files;
-
-	// Get all the relative file names from each of the file data.
-	std::vector<std::string> GetRelativeFileNames();
 };
 
 struct ChangedFileGroups

--- a/p4-fusion/commands/change_list.cc
+++ b/p4-fusion/commands/change_list.cc
@@ -11,6 +11,7 @@
 #include "filelog_result.h"
 #include "print_result.h"
 #include "utils/std_helpers.h"
+#include "utils/p4_depot_path.h"
 
 #include "thread_pool.h"
 #include "lfs/communication/communicator.h"
@@ -120,7 +121,7 @@ void ChangeList::DownloadBatch(std::shared_ptr<std::vector<std::string>> printBa
 				const PrintResult& printData = p4->PrintFiles(*printBatchFiles);
 			    for (int i = 0; i < printBatchFiles->size(); i++)
 			    {
-					auto& filePath = printBatchFileData->at(i)->GetRelativePathForGit();
+					std::string filePath = P4Unescape(printBatchFileData->at(i)->GetRelativeDepotPath());
 					// If in LFS mode, we determine whether a file is LFS-tracked, and if so, we do produce a pointer file and upload the file contents.
 					if (! lfsClient ||  !lfsClient->IsLFSTracked(filePath))
 					{

--- a/p4-fusion/commands/change_list.cc
+++ b/p4-fusion/commands/change_list.cc
@@ -120,14 +120,15 @@ void ChangeList::DownloadBatch(std::shared_ptr<std::vector<std::string>> printBa
 				const PrintResult& printData = p4->PrintFiles(*printBatchFiles);
 			    for (int i = 0; i < printBatchFiles->size(); i++)
 			    {
+					auto& filePath = printBatchFileData->at(i)->GetRelativePathForGit();
 					// If in LFS mode, we determine whether a file is LFS-tracked, and if so, we do produce a pointer file and upload the file contents.
-					if (! lfsClient ||  !lfsClient->IsLFSTracked(printBatchFileData->at(i)->GetRelativePath()))
+					if (! lfsClient ||  !lfsClient->IsLFSTracked(filePath))
 					{
 						printBatchFileData->at(i)->MoveContentsOnceFrom(printData.GetPrintData().at(i).contents);
-					} else
+					}
+					else
 					{
 						const auto& fileContents = printData.GetPrintData().at(i).contents;
-						auto& filePath = printBatchFileData->at(i)->GetRelativePath();
 						const std::vector<char> pointerFileContents = lfsClient->CreatePointerFileContents(fileContents);
 						Communicator::UploadResult uploadResult = lfsClient->UploadFile(fileContents);
 						switch (uploadResult)

--- a/p4-fusion/commands/file_data.cc
+++ b/p4-fusion/commands/file_data.cc
@@ -93,6 +93,7 @@ void FileData::SetRelativePathForGit(std::string relativePath)
 	ReplaceAll(relativePath, "%40", "@");
 	ReplaceAll(relativePath, "%23", "#");
 	ReplaceAll(relativePath, "%2A", "*");
+	// Replace %25 last to avoid interfering with other escape sequences
 	ReplaceAll(relativePath, "%25", "%");
 	m_data->relativePath = relativePath;
 }

--- a/p4-fusion/commands/file_data.cc
+++ b/p4-fusion/commands/file_data.cc
@@ -6,18 +6,6 @@
  */
 #include "file_data.h"
 
-static void ReplaceAll(std::string& str, const std::string& find, const std::string& replace)
-{
-	std::string::size_type pos;
-	std::string::size_type startPos = 0;
-
-	while ((pos = str.find(find, startPos)) != std::string::npos)
-	{
-		str.replace(pos, find.length(), replace);
-		startPos = pos + replace.length();
-	}
-}
-
 FileDataStore::FileDataStore()
     : actionCategory(FileAction::FileAdd)
     , isContentsSet(false)
@@ -88,13 +76,8 @@ void FileData::SetPendingDownload()
 	}
 }
 
-void FileData::SetRelativePathForGit(std::string relativePath)
+void FileData::SetRelativeDepotPath(const std::string& relativePath)
 {
-	ReplaceAll(relativePath, "%40", "@");
-	ReplaceAll(relativePath, "%23", "#");
-	ReplaceAll(relativePath, "%2A", "*");
-	// Replace %25 last to avoid interfering with other escape sequences
-	ReplaceAll(relativePath, "%25", "%");
 	m_data->relativePath = relativePath;
 }
 

--- a/p4-fusion/commands/file_data.cc
+++ b/p4-fusion/commands/file_data.cc
@@ -14,7 +14,7 @@ static void ReplaceAll(std::string& str, const std::string& find, const std::str
 	while ((pos = str.find(find, startPos)) != std::string::npos)
 	{
 		str.replace(pos, find.length(), replace);
-		startPos = pos + 1;
+		startPos = pos + replace.length();
 	}
 }
 

--- a/p4-fusion/commands/file_data.cc
+++ b/p4-fusion/commands/file_data.cc
@@ -6,6 +6,18 @@
  */
 #include "file_data.h"
 
+static void ReplaceAll(std::string& str, const std::string& find, const std::string& replace)
+{
+	std::string::size_type pos;
+	std::string::size_type startPos = 0;
+
+	while ((pos = str.find(find, startPos)) != std::string::npos)
+	{
+		str.replace(pos, find.length(), replace);
+		startPos = pos + 1;
+	}
+}
+
 FileDataStore::FileDataStore()
     : actionCategory(FileAction::FileAdd)
     , isContentsSet(false)
@@ -76,8 +88,12 @@ void FileData::SetPendingDownload()
 	}
 }
 
-void FileData::SetRelativePath(std::string& relativePath)
+void FileData::SetRelativePathForGit(std::string relativePath)
 {
+	ReplaceAll(relativePath, "%40", "@");
+	ReplaceAll(relativePath, "%23", "#");
+	ReplaceAll(relativePath, "%2A", "*");
+	ReplaceAll(relativePath, "%25", "%");
 	m_data->relativePath = relativePath;
 }
 

--- a/p4-fusion/commands/file_data.h
+++ b/p4-fusion/commands/file_data.h
@@ -76,7 +76,7 @@ public:
 	FileData& operator=(FileData& other);
 
 	void SetFromDepotFile(const std::string& fromDepotFile, const std::string& fromRevision);
-	void SetRelativePathForGit(std::string relativePath);
+	void SetRelativeDepotPath(const std::string& relativePath);
 	void SetFakeIntegrationDeleteAction() { m_data->SetAction(FAKE_INTEGRATION_DELETE_ACTION_NAME); };
 
 	// moves the argument's data into this file data structure.
@@ -88,7 +88,7 @@ public:
 	const std::string& GetDepotFile() const { return m_data->depotFile; };
 	const std::string& GetRevision() const { return m_data->revision; };
 	const FileAction GetAction() const { return m_data->actionCategory; };
-	const std::string& GetRelativePathForGit() const { return m_data->relativePath; };
+	const std::string& GetRelativeDepotPath() const { return m_data->relativePath; };
 	const std::vector<char>& GetContents() const { return m_data->contents; };
 	bool IsDeleted() const { return m_data->isDeleted; };
 	bool IsIntegrated() const { return m_data->isIntegrated; };

--- a/p4-fusion/commands/file_data.h
+++ b/p4-fusion/commands/file_data.h
@@ -76,7 +76,7 @@ public:
 	FileData& operator=(FileData& other);
 
 	void SetFromDepotFile(const std::string& fromDepotFile, const std::string& fromRevision);
-	void SetRelativePath(std::string& relativePath);
+	void SetRelativePathForGit(std::string relativePath);
 	void SetFakeIntegrationDeleteAction() { m_data->SetAction(FAKE_INTEGRATION_DELETE_ACTION_NAME); };
 
 	// moves the argument's data into this file data structure.
@@ -88,7 +88,7 @@ public:
 	const std::string& GetDepotFile() const { return m_data->depotFile; };
 	const std::string& GetRevision() const { return m_data->revision; };
 	const FileAction GetAction() const { return m_data->actionCategory; };
-	const std::string& GetRelativePath() const { return m_data->relativePath; };
+	const std::string& GetRelativePathForGit() const { return m_data->relativePath; };
 	const std::vector<char>& GetContents() const { return m_data->contents; };
 	bool IsDeleted() const { return m_data->isDeleted; };
 	bool IsIntegrated() const { return m_data->isIntegrated; };

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -136,7 +136,7 @@ int Main(int argc, char** argv)
 	std::unique_ptr<LFSClient> lfsClient;
 	if (!lfsPatterns.empty() && !lfsServerUrl.empty() && !lfsAPI.empty())
 	{
- 		std::unique_ptr<Communicator> communicator;
+		std::unique_ptr<Communicator> communicator;
 		if (lfsAPI == "s3")
 		{
 			communicator.reset(new S3Comm(lfsServerUrl, lfsS3Bucket, lfsS3Repository, lfsUsername, lfsPassword));
@@ -470,11 +470,11 @@ int Main(int argc, char** argv)
 			{
 				if (file.IsDeleted())
 				{
-					git.RemoveFileFromIndex(file.GetRelativePath());
+					git.RemoveFileFromIndex(file.GetRelativePathForGit());
 				}
 				else
 				{
-					git.AddFileToIndex(file.GetRelativePath(), file.GetContents(), file.IsExecutable());
+					git.AddFileToIndex(file.GetRelativePathForGit(), file.GetContents(), file.IsExecutable());
 				}
 
 				// No use for keeping the contents in memory once it has been added

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -24,6 +24,7 @@
 #include "utils/std_helpers.h"
 #include "utils/timer.h"
 #include "utils/arguments.h"
+#include "utils/p4_depot_path.h"
 
 #include "thread_pool.h"
 #include "p4_api.h"
@@ -468,13 +469,14 @@ int Main(int argc, char** argv)
 
 			for (auto& file : branchGroup.files)
 			{
+				std::string unescapedPath = P4Unescape(file.GetRelativeDepotPath());
 				if (file.IsDeleted())
 				{
-					git.RemoveFileFromIndex(file.GetRelativePathForGit());
+					git.RemoveFileFromIndex(unescapedPath);
 				}
 				else
 				{
-					git.AddFileToIndex(file.GetRelativePathForGit(), file.GetContents(), file.IsExecutable());
+					git.AddFileToIndex(unescapedPath, file.GetContents(), file.IsExecutable());
 				}
 
 				// No use for keeping the contents in memory once it has been added

--- a/p4-fusion/utils/p4_depot_path.cc
+++ b/p4-fusion/utils/p4_depot_path.cc
@@ -170,3 +170,13 @@ bool P4DepotPath::operator!=(const P4DepotPath& other) const
 {
 	return !(*this == other);
 }
+
+std::string P4Unescape(std::string p4path)
+{
+	STDHelpers::ReplaceAll(p4path, "%40", "@");
+	STDHelpers::ReplaceAll(p4path, "%23", "#");
+	STDHelpers::ReplaceAll(p4path, "%2A", "*");
+	// Replace %25 last to avoid interfering with other escape sequences
+	STDHelpers::ReplaceAll(p4path, "%25", "%");
+	return p4path;
+}

--- a/p4-fusion/utils/p4_depot_path.h
+++ b/p4-fusion/utils/p4_depot_path.h
@@ -71,3 +71,5 @@ struct hash<P4DepotPath>
 	}
 };
 }
+
+std::string P4Unescape(std::string p4path);

--- a/p4-fusion/utils/std_helpers.cc
+++ b/p4-fusion/utils/std_helpers.cc
@@ -74,6 +74,18 @@ std::string STDHelpers::ToLower(const std::string& source)
 	return result;
 }
 
+void STDHelpers::ReplaceAll(std::string& str, const std::string& find, const std::string& replace)
+{
+	std::string::size_type pos;
+	std::string::size_type startPos = 0;
+
+	while ((pos = str.find(find, startPos)) != std::string::npos)
+	{
+		str.replace(pos, find.length(), replace);
+		startPos = pos + replace.length();
+	}
+}
+
 std::array<std::string, 2> STDHelpers::SplitAt(const std::string& source, const char c, const size_t startAt)
 {
 	size_t pos = source.find(c, startAt);

--- a/p4-fusion/utils/std_helpers.h
+++ b/p4-fusion/utils/std_helpers.h
@@ -19,6 +19,7 @@ public:
 	static void Erase(std::string& source, const std::string& subStr);
 	static void StripSurrounding(std::string& source, const char c);
 	static std::string ToLower(const std::string& source);
+	static void ReplaceAll(std::string& str, const std::string& find, const std::string& replace);
 
 	// Split the source into two strings at the first character 'c' after position 'startAt'.  The 'c' character is
 	// not included in the returned strings.  Text before the 'startAt' will not be included.


### PR DESCRIPTION
As [documented](https://help.perforce.com/helix-core/server-apps/p4guide/2022.2/Content/P4Guide/syntax.syntax.restrictions.html), P4 escapes four special characters in filenames:

| Char | Escape |
|---|-----|
| @ | %40 |
| # | %23 |
| * | %2A |
| % | %25 |

P4V restores the original filenames when syncing a file, but in the command line output of p4 commands the escapes are not restored, therefore the escape sequences "escaped" through p4-fusion into the Git repo filenames. This change resolves this bug.