### PR TITLE
style: clang format fixes

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -8,8 +8,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: DoozyX/clang-format-lint-action@v0.13
+    - uses: DoozyX/clang-format-lint-action@v0.20
       with:
         source: 'p4-fusion tests'
         extensions: 'h,cc'
-        clangFormatVersion: 12.0.1
+        clangFormatVersion: 20

--- a/p4-fusion/commands/change_list.cc
+++ b/p4-fusion/commands/change_list.cc
@@ -56,8 +56,7 @@ void ChangeList::PrepareDownload(const BranchSet& branchSet)
 
 		    std::unique_lock<std::mutex> lock(*cl.stateMutex);
 		    cl.state = Described;
-		    cl.stateCV->notify_all();
-	    });
+		    cl.stateCV->notify_all(); });
 }
 
 void ChangeList::StartDownloadAndLFSUpload(int nPrintBatch)
@@ -108,8 +107,7 @@ void ChangeList::StartDownloadAndLFSUpload(int nPrintBatch)
 
 		    // Download any remaining files that were smaller in number than the total batch size.
 		    // Additionally, signal the batch processing end.
-		    cl.DownloadBatch(printBatchFiles, printBatchFileData);
-	    });
+		    cl.DownloadBatch(printBatchFiles, printBatchFileData); });
 }
 
 void ChangeList::DownloadBatch(std::shared_ptr<std::vector<std::string>> printBatchFiles, std::shared_ptr<std::vector<FileData*>> printBatchFileData)
@@ -160,8 +158,7 @@ void ChangeList::DownloadBatch(std::shared_ptr<std::vector<std::string>> printBa
 		    {
 			    state = CommitReady;
 			    stateCV->notify_all();
-		    }
-	    });
+		    } });
 }
 
 void ChangeList::WaitForBeingCommitReady()

--- a/p4-fusion/commands/change_list.cc
+++ b/p4-fusion/commands/change_list.cc
@@ -56,7 +56,8 @@ void ChangeList::PrepareDownload(const BranchSet& branchSet)
 
 		    std::unique_lock<std::mutex> lock(*cl.stateMutex);
 		    cl.state = Described;
-		    cl.stateCV->notify_all(); });
+		    cl.stateCV->notify_all();
+	    });
 }
 
 void ChangeList::StartDownloadAndLFSUpload(int nPrintBatch)
@@ -107,7 +108,8 @@ void ChangeList::StartDownloadAndLFSUpload(int nPrintBatch)
 
 		    // Download any remaining files that were smaller in number than the total batch size.
 		    // Additionally, signal the batch processing end.
-		    cl.DownloadBatch(printBatchFiles, printBatchFileData); });
+		    cl.DownloadBatch(printBatchFiles, printBatchFileData);
+	    });
 }
 
 void ChangeList::DownloadBatch(std::shared_ptr<std::vector<std::string>> printBatchFiles, std::shared_ptr<std::vector<FileData*>> printBatchFileData)
@@ -118,37 +120,37 @@ void ChangeList::DownloadBatch(std::shared_ptr<std::vector<std::string>> printBa
 		    // Only perform the batch processing when there are files to process.
 		    if (!printBatchFileData->empty())
 		    {
-				const PrintResult& printData = p4->PrintFiles(*printBatchFiles);
+			    const PrintResult& printData = p4->PrintFiles(*printBatchFiles);
 			    for (int i = 0; i < printBatchFiles->size(); i++)
 			    {
-					std::string filePath = P4Unescape(printBatchFileData->at(i)->GetRelativeDepotPath());
-					// If in LFS mode, we determine whether a file is LFS-tracked, and if so, we do produce a pointer file and upload the file contents.
-					if (! lfsClient ||  !lfsClient->IsLFSTracked(filePath))
-					{
-						printBatchFileData->at(i)->MoveContentsOnceFrom(printData.GetPrintData().at(i).contents);
-					}
-					else
-					{
-						const auto& fileContents = printData.GetPrintData().at(i).contents;
-						const std::vector<char> pointerFileContents = lfsClient->CreatePointerFileContents(fileContents);
-						Communicator::UploadResult uploadResult = lfsClient->UploadFile(fileContents);
-						switch (uploadResult)
-						{
-							case Communicator::UploadResult::Uploaded:
-								SUCCESS("Uploaded file " << filePath << " to LFS (" << fileContents.size() << " bytes)");
-								break;
-							case Communicator::UploadResult::AlreadyExists:
-								SUCCESS("File " << filePath << " already exists in LFS, skipping upload");
-								break;
-							case Communicator::UploadResult::Error:
-								ERR("Failed to upload file " << filePath << " to LFS");
-								// Not nice, but we have no other means to signal any intermediate errors from here
-								std::abort();
-						}
+				    std::string filePath = P4Unescape(printBatchFileData->at(i)->GetRelativeDepotPath());
+				    // If in LFS mode, we determine whether a file is LFS-tracked, and if so, we do produce a pointer file and upload the file contents.
+				    if (!lfsClient || !lfsClient->IsLFSTracked(filePath))
+				    {
+					    printBatchFileData->at(i)->MoveContentsOnceFrom(printData.GetPrintData().at(i).contents);
+				    }
+				    else
+				    {
+					    const auto& fileContents = printData.GetPrintData().at(i).contents;
+					    const std::vector<char> pointerFileContents = lfsClient->CreatePointerFileContents(fileContents);
+					    Communicator::UploadResult uploadResult = lfsClient->UploadFile(fileContents);
+					    switch (uploadResult)
+					    {
+					    case Communicator::UploadResult::Uploaded:
+						    SUCCESS("Uploaded file " << filePath << " to LFS (" << fileContents.size() << " bytes)");
+						    break;
+					    case Communicator::UploadResult::AlreadyExists:
+						    SUCCESS("File " << filePath << " already exists in LFS, skipping upload");
+						    break;
+					    case Communicator::UploadResult::Error:
+						    ERR("Failed to upload file " << filePath << " to LFS");
+						    // Not nice, but we have no other means to signal any intermediate errors from here
+						    std::abort();
+					    }
 
-						// git blob content should be a pointer file, so replace the contents
-						printBatchFileData->at(i)->MoveContentsOnceFrom(pointerFileContents);
-					}
+					    // git blob content should be a pointer file, so replace the contents
+					    printBatchFileData->at(i)->MoveContentsOnceFrom(pointerFileContents);
+				    }
 			    }
 		    }
 
@@ -158,7 +160,8 @@ void ChangeList::DownloadBatch(std::shared_ptr<std::vector<std::string>> printBa
 		    {
 			    state = CommitReady;
 			    stateCV->notify_all();
-		    } });
+		    }
+	    });
 }
 
 void ChangeList::WaitForBeingCommitReady()

--- a/p4-fusion/lfs/communication/lfscomm.cc
+++ b/p4-fusion/lfs/communication/lfscomm.cc
@@ -26,11 +26,12 @@ const char* GetUserAgent()
 	static std::once_flag init_flag;
 	std::call_once(init_flag, []()
 	    {
-		curl_version_info_data* version_info = curl_version_info(CURLVERSION_NOW);
-		if (version_info && version_info->version)
-		{
-			result = std::string("curl/") + version_info->version;
-		} });
+		    curl_version_info_data* version_info = curl_version_info(CURLVERSION_NOW);
+		    if (version_info && version_info->version)
+		    {
+			    result = std::string("curl/") + version_info->version;
+		    }
+	    });
 
 	return result.c_str();
 }
@@ -191,14 +192,16 @@ RequestResult PerformPostRequestWithRetry(CURL* curl,
 	SetupRequest(curl, url, data, data_size, headers, &result, auth);
 
 	return PerformRequestWithRetry([&]() -> RequestResult
-	    {        
-        result.curl_result = curl_easy_perform(curl);
-        
-        if (result.curl_result == CURLE_OK) {
-            curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &result.response_code);
-        }
-        
-        return result; });
+	    {
+		    result.curl_result = curl_easy_perform(curl);
+
+		    if (result.curl_result == CURLE_OK)
+		    {
+			    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &result.response_code);
+		    }
+
+		    return result;
+	    });
 }
 
 // Helper function to perform a PUT request with binary data
@@ -214,13 +217,15 @@ RequestResult PerformPutRequestWithRetry(CURL* curl, const std::string& url,
 
 	return PerformRequestWithRetry([&]() -> RequestResult
 	    {
-        result.curl_result = curl_easy_perform(curl);
-        
-        if (result.curl_result == CURLE_OK) {
-            curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &result.response_code);
-        }
-        
-        return result; });
+		    result.curl_result = curl_easy_perform(curl);
+
+		    if (result.curl_result == CURLE_OK)
+		    {
+			    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &result.response_code);
+		    }
+
+		    return result;
+	    });
 }
 
 struct BatchResponse
@@ -397,11 +402,13 @@ Communicator::UploadResult PerformUpload(const std::string& uploadUrl, const std
 
 	uploadResult = PerformRequestWithRetry([&]() -> RequestResult
 	    {
-		uploadResult.curl_result = curl_easy_perform(curl.get());
-		if (uploadResult.curl_result == CURLE_OK) {
-			curl_easy_getinfo(curl.get(), CURLINFO_RESPONSE_CODE, &uploadResult.response_code);
-		}
-		return uploadResult; });
+		    uploadResult.curl_result = curl_easy_perform(curl.get());
+		    if (uploadResult.curl_result == CURLE_OK)
+		    {
+			    curl_easy_getinfo(curl.get(), CURLINFO_RESPONSE_CODE, &uploadResult.response_code);
+		    }
+		    return uploadResult;
+	    });
 
 	curl_slist_free_all(uploadHeaders);
 
@@ -454,11 +461,13 @@ bool PerformVerify(const std::string& verifyUrl, const std::string& oid, size_t 
 
 	verifyResult = PerformRequestWithRetry([&]() -> RequestResult
 	    {
-		verifyResult.curl_result = curl_easy_perform(curl.get());
-		if (verifyResult.curl_result == CURLE_OK) {
-			curl_easy_getinfo(curl.get(), CURLINFO_RESPONSE_CODE, &verifyResult.response_code);
-		}
-		return verifyResult; });
+		    verifyResult.curl_result = curl_easy_perform(curl.get());
+		    if (verifyResult.curl_result == CURLE_OK)
+		    {
+			    curl_easy_getinfo(curl.get(), CURLINFO_RESPONSE_CODE, &verifyResult.response_code);
+		    }
+		    return verifyResult;
+	    });
 
 	curl_slist_free_all(verifyHeaders);
 

--- a/p4-fusion/lfs/communication/lfscomm.cc
+++ b/p4-fusion/lfs/communication/lfscomm.cc
@@ -30,8 +30,7 @@ const char* GetUserAgent()
 		    if (version_info && version_info->version)
 		    {
 			    result = std::string("curl/") + version_info->version;
-		    }
-	    });
+		    } });
 
 	return result.c_str();
 }
@@ -200,8 +199,7 @@ RequestResult PerformPostRequestWithRetry(CURL* curl,
 			    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &result.response_code);
 		    }
 
-		    return result;
-	    });
+		    return result; });
 }
 
 // Helper function to perform a PUT request with binary data
@@ -224,8 +222,7 @@ RequestResult PerformPutRequestWithRetry(CURL* curl, const std::string& url,
 			    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &result.response_code);
 		    }
 
-		    return result;
-	    });
+		    return result; });
 }
 
 struct BatchResponse
@@ -407,8 +404,7 @@ Communicator::UploadResult PerformUpload(const std::string& uploadUrl, const std
 		    {
 			    curl_easy_getinfo(curl.get(), CURLINFO_RESPONSE_CODE, &uploadResult.response_code);
 		    }
-		    return uploadResult;
-	    });
+		    return uploadResult; });
 
 	curl_slist_free_all(uploadHeaders);
 
@@ -466,8 +462,7 @@ bool PerformVerify(const std::string& verifyUrl, const std::string& oid, size_t 
 		    {
 			    curl_easy_getinfo(curl.get(), CURLINFO_RESPONSE_CODE, &verifyResult.response_code);
 		    }
-		    return verifyResult;
-	    });
+		    return verifyResult; });
 
 	curl_slist_free_all(verifyHeaders);
 

--- a/p4-fusion/lfs/communication/s3comm.cc
+++ b/p4-fusion/lfs/communication/s3comm.cc
@@ -37,7 +37,7 @@ Communicator::UploadResult S3Comm::UploadFile(const std::vector<char>& fileConte
 
 	std::string objectKey = m_Repository + "/" + oid;
 
-	//Check if object already exists
+	// Check if object already exists
 	Aws::S3::Model::HeadObjectRequest headRequest;
 	headRequest.SetBucket(m_Bucket);
 	headRequest.SetKey(objectKey);

--- a/p4-fusion/lfs/communication/s3comm.cc
+++ b/p4-fusion/lfs/communication/s3comm.cc
@@ -10,11 +10,11 @@
 #include <aws/core/utils/stream/PreallocatedStreamBuf.h>
 
 S3Comm::S3Comm(const std::string& serverURL, const std::string& bucket, const std::string& repository, const std::string& username, const std::string& password)
-	: m_ServerURL(serverURL)
-	, m_Bucket(bucket)
-	, m_Repository(repository)
-	, m_Username(username)
-	, m_Password(password)
+    : m_ServerURL(serverURL)
+    , m_Bucket(bucket)
+    , m_Repository(repository)
+    , m_Username(username)
+    , m_Password(password)
 {
 }
 
@@ -26,14 +26,14 @@ Communicator::UploadResult S3Comm::UploadFile(const std::vector<char>& fileConte
 
 	bool isHttps = m_ServerURL.find("https://") == 0;
 
-    Aws::S3::S3ClientConfiguration config;
-    config.endpointOverride = m_ServerURL;
-    config.scheme = isHttps ? Aws::Http::Scheme::HTTPS : Aws::Http::Scheme::HTTP;
-    config.verifySSL = isHttps;
+	Aws::S3::S3ClientConfiguration config;
+	config.endpointOverride = m_ServerURL;
+	config.scheme = isHttps ? Aws::Http::Scheme::HTTPS : Aws::Http::Scheme::HTTP;
+	config.verifySSL = isHttps;
 	config.useVirtualAddressing = false;
 
 	Aws::S3::S3Client s3Client(credentials, config,
-	Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false);
+	    Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false);
 
 	std::string objectKey = m_Repository + "/" + oid;
 
@@ -53,15 +53,13 @@ Communicator::UploadResult S3Comm::UploadFile(const std::vector<char>& fileConte
 	objectRequest.SetKey(objectKey);
 
 	auto streamBuf = Aws::MakeShared<Aws::Utils::Stream::PreallocatedStreamBuf>("",
-		reinterpret_cast<unsigned char*>(const_cast<char*>(fileContents.data())), 
-		fileContents.size());
+	    reinterpret_cast<unsigned char*>(const_cast<char*>(fileContents.data())),
+	    fileContents.size());
 	auto stream = Aws::MakeShared<Aws::IOStream>("", streamBuf.get());
-    stream->seekg(0, std::ios::beg);
+	stream->seekg(0, std::ios::beg);
 
-    objectRequest.SetBody(stream);
+	objectRequest.SetBody(stream);
 
 	auto uploadResult = s3Client.PutObject(objectRequest);
-	return uploadResult.IsSuccess() ?
-		UploadResult::Uploaded :
-		UploadResult::Error;
+	return uploadResult.IsSuccess() ? UploadResult::Uploaded : UploadResult::Error;
 }

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -424,7 +424,8 @@ int Main(int argc, char** argv)
 
 	// Check if all changelists appear only once
 	std::set<std::string> uniqueChangeListNumbers;
-	for (const ChangeList& cl : changes) {
+	for (const ChangeList& cl : changes)
+	{
 		uniqueChangeListNumbers.insert(cl.number);
 	}
 	if (uniqueChangeListNumbers.size() != changes.size())

--- a/p4-fusion/p4_api.cc
+++ b/p4-fusion/p4_api.cc
@@ -205,7 +205,8 @@ ChangesResult P4API::Changes(const std::string& path, const std::string& from, i
 {
 	std::vector<std::string> args = {
 		"-l", // Get full descriptions instead of sending cut-short ones
-		"-s", "submitted", // Only include submitted CLs
+		"-s",
+		"submitted", // Only include submitted CLs
 	};
 
 	// This needs to be declared outside the if scope below to

--- a/p4-fusion/thread_pool.cc
+++ b/p4-fusion/thread_pool.cc
@@ -134,8 +134,7 @@ void ThreadPool::Initialize(int size, LFSClient* lfsClient)
 					    m_ThreadExceptions[i] = std::current_exception();
 				    }
 				    m_JobsProcessing--;
-			    }
-		    }));
+			    } }));
 	}
 }
 

--- a/p4-fusion/thread_pool.cc
+++ b/p4-fusion/thread_pool.cc
@@ -134,7 +134,8 @@ void ThreadPool::Initialize(int size, LFSClient* lfsClient)
 					    m_ThreadExceptions[i] = std::current_exception();
 				    }
 				    m_JobsProcessing--;
-			    } }));
+			    }
+		    }));
 	}
 }
 

--- a/p4-fusion/utils/arguments.cc
+++ b/p4-fusion/utils/arguments.cc
@@ -42,12 +42,23 @@ static std::unique_ptr<std::vector<std::string>> ArgsFromFile(const std::string&
 		std::string errorMessage;
 		switch (resultCode)
 		{
-			case WRDE_BADCHAR: errorMessage = "Illegal newline or |&;<>(){}"; break; 
-			case WRDE_BADVAL: errorMessage = "An undefined shell variable was referenced"; break;
-			case WRDE_CMDSUB: errorMessage = "Command substitution not allowed"; break;
-			case WRDE_NOSPACE: errorMessage = "Out of memory"; break;
-			case WRDE_SYNTAX: errorMessage = "Syntax error"; break;
-			default: break;
+		case WRDE_BADCHAR:
+			errorMessage = "Illegal newline or |&;<>(){}";
+			break;
+		case WRDE_BADVAL:
+			errorMessage = "An undefined shell variable was referenced";
+			break;
+		case WRDE_CMDSUB:
+			errorMessage = "Command substitution not allowed";
+			break;
+		case WRDE_NOSPACE:
+			errorMessage = "Out of memory";
+			break;
+		case WRDE_SYNTAX:
+			errorMessage = "Syntax error";
+			break;
+		default:
+			break;
 		}
 		ERR("Error parsing config file: " << errorMessage);
 		return nullptr;
@@ -190,13 +201,12 @@ bool Arguments::IsValid() const
 		}
 	}
 
-	const bool hasAnyLFSParam = !GetLFSSpecs().empty() || !GetLFSServerUrl().empty() ||
-		!GetLFSUsername().empty() || !GetLFSPassword().empty() || !GetLFSToken().empty() || !GetLFSAPI().empty() ||
-		!GetLFSS3Bucket().empty() || !GetLFSS3Repository().empty();
+	const bool hasAnyLFSParam = !GetLFSSpecs().empty() || !GetLFSServerUrl().empty() || !GetLFSUsername().empty() || !GetLFSPassword().empty() || !GetLFSToken().empty() || !GetLFSAPI().empty() || !GetLFSS3Bucket().empty() || !GetLFSS3Repository().empty();
 	const bool hasAllLFSParams = !GetLFSSpecs().empty() && !GetLFSServerUrl().empty() && !GetLFSAPI().empty();
 	if (hasAnyLFSParam && !hasAllLFSParams)
 		return false;
-	if (hasAnyLFSParam) {
+	if (hasAnyLFSParam)
+	{
 		const std::string& lfsAPI = GetLFSAPI();
 		if (lfsAPI != "lfs" && lfsAPI != "s3")
 		{

--- a/p4-fusion/utils/arguments.h
+++ b/p4-fusion/utils/arguments.h
@@ -26,7 +26,7 @@ class Arguments
 
 	std::string GetParameter(const std::string& argName) const;
 	std::vector<std::string> GetParameterList(const std::string& argName) const;
-	void AddArgumentsFromFile (const std::string& filename);
+	void AddArgumentsFromFile(const std::string& filename);
 	bool ValidateS3Bucket() const;
 
 public:


### PR DESCRIPTION
I create this PR to act as a base for [this](push origin temp-create-github-release:create-github-release --force-with-lease) PR. This ensures that the code style changes do not overshadow the functional changes. The build action will fail here, because it is outdated.

For future reference:
The clang-format action uses clang-format@12.0.1 (currently brew installs v21.) Installing versioned formulaes from brew is disabled since 2025-07-01. To work around this, I used a podman container. This can be set up like so:
1. `podman machine init`
2. `podman machine ssh`
3. Now inside the container `sudo -i`
```zsh
cat <<EOF > /etc/pki/ca-trust/source/anchors/vpn-ca.crt
-----BEGIN CERTIFICATE-----
... (paste your actual certificate content here from ca.crt) ...
-----END CERTIFICATE-----
EOF
```
4. `update-ca-trust`
5. `exit` (su shell) and `exit` (container)
6. `podman machine stop` and `podman machine start`

Now it is possible to pull images from the internet.
Finally, to do the actual formatting, run this from the repository root:
```zsh
podman run --rm -v "$PWD":/work -w /work ubuntu:22.04 bash -c \
    "apt-get update && apt-get install -y clang-format-12 && \
    find p4-fusion tests \( -name '*.h' -o -name '*.cc' \) | xargs clang-format-12 -i -style=file"
```