### PR TITLE
Enable testing on macos

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,7 @@ jobs:
 
     - name: Generate CMake project
       run: |
-        ./generate_cache.sh Release p
+        ./generate_cache.sh Release pt
 
     - name: Build
       run: |
@@ -75,6 +75,10 @@ jobs:
 
         echo "Help output"
         "$BINARY_PATH" --help
+
+    - name: Test
+      run: |
+          ./build/tests/p4-fusion-test
 
     - name: Package binary
       run: |

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,4 @@
+find_package(OpenSSL REQUIRED)
 add_executable(p4-fusion-test 
     main.cc
 
@@ -7,6 +8,7 @@ add_executable(p4-fusion-test
     ../p4-fusion/utils/std_helpers.cc
     ../p4-fusion/utils/time_helpers.cc
     ../p4-fusion/git_api.cc
+    ../p4-fusion/lfs/lfs_client.cc
     ../p4-fusion/log.cc
 )
 
@@ -15,8 +17,17 @@ target_include_directories(p4-fusion-test PRIVATE
     ../${HELIX_API}/include/
     ../vendor/libgit2/include/
     ../vendor/minitrace/
+    ${OPENSSL_INCLUDE_DIR}
 )
 
 target_link_libraries(p4-fusion-test PRIVATE
-    git2
+    libgit2package
+    ${OPENSSL_SSL_LIBRARIES}
+    ${OPENSSL_CRYPTO_LIBRARIES}
 )
+
+if (APPLE)
+    find_library(COREFOUNDATION_LIB CoreFoundation REQUIRED)
+    target_link_libraries(p4-fusion-test PRIVATE ${COREFOUNDATION_LIB})
+endif(APPLE)
+

--- a/tests/tests.git.h
+++ b/tests/tests.git.h
@@ -16,7 +16,7 @@ int TestGitAPI()
 	GitAPI git(false);
 
 	TEST(git.InitializeRepository("/tmp/test-repo"), true);
-	git.CreateIndex();
+	git.CreateIndex(nullptr);
 	git.AddFileToIndex("foo.txt", { 'x', 'y', 'z' }, false);
 	git.Commit(
 	    "//a/b/c/...",
@@ -28,9 +28,11 @@ int TestGitAPI()
 	    10000000,
 	    "");
 	TEST(git.IsHEADExists(), true);
-	TEST(git.IsRepositoryClonedFrom("//a/b/c/..."), true);
-	TEST(git.IsRepositoryClonedFrom("//a/b/c/d/..."), false);
-	TEST(git.IsRepositoryClonedFrom("//x/y/z/..."), false);
+
+	auto depoPath = git.GetDepotPathFromLastCommit();
+	TEST(depoPath, "//a/b/c/...");
+	TEST_NEQ(depoPath, "//a/b/c/d/...");
+	TEST_NEQ(depoPath, "//x/y/z/...");
 	TEST(git.DetectLatestCL(), "12345678");
 
 	git.RemoveFileFromIndex("foo.txt");
@@ -44,9 +46,11 @@ int TestGitAPI()
 	    20000000,
 	    "");
 	TEST(git.IsHEADExists(), true);
-	TEST(git.IsRepositoryClonedFrom("//a/b/c/..."), true);
-	TEST(git.IsRepositoryClonedFrom("//a/b/c/d/..."), false);
-	TEST(git.IsRepositoryClonedFrom("//x/y/z/..."), false);
+
+	depoPath = git.GetDepotPathFromLastCommit();
+	TEST(depoPath, "//a/b/c/...");
+	TEST_NEQ(depoPath, "//a/b/c/d/...");
+	TEST_NEQ(depoPath, "//x/y/z/...");
 	TEST(git.DetectLatestCL(), "12345679");
 
 	git.CloseIndex();


### PR DESCRIPTION
- enable compiling and running tests during ci
- update test's CMakeLists.txt to include all required dependencies
- test for `GetDepotPathFromLastCommit()`