### PR TITLE
Fix usage without LFS

### DIFF
--- a/p4-fusion/utils/arguments.cc
+++ b/p4-fusion/utils/arguments.cc
@@ -201,7 +201,7 @@ bool Arguments::IsValid() const
 		}
 	}
 
-	const bool hasAnyLFSParam = !GetLFSSpecs().empty() || !GetLFSServerUrl().empty() || !GetLFSUsername().empty() || !GetLFSPassword().empty() || !GetLFSToken().empty() || !GetLFSAPI().empty() || !GetLFSS3Bucket().empty() || !GetLFSS3Repository().empty();
+	const bool hasAnyLFSParam = !GetLFSSpecs().empty() || !GetLFSServerUrl().empty() || !GetLFSUsername().empty() || !GetLFSPassword().empty() || !GetLFSToken().empty() || !GetLFSS3Bucket().empty() || !GetLFSS3Repository().empty();
 	const bool hasAllLFSParams = !GetLFSSpecs().empty() && !GetLFSServerUrl().empty() && !GetLFSAPI().empty();
 	if (hasAnyLFSParam && !hasAllLFSParams)
 		return false;


### PR DESCRIPTION
This change re-enables usage of p4-fusion without LFS.

Before the change, the cmdline option `--lfsAPI` is set to 'lfs' by default, but if the user does not provide any lfs options, the validation fails because it considers the default value as indication that the user wanted LFS. 

This is fixed by not considering this option in validation. This seems to be the more user friendly solution; the alternative would be to set `--lfsAPI` to empty by default, and require any LFS user to set it explicitly to 'lfs'.