### PR TITLE
ACP-24292 p4-fusion continue previous run function didn't work with branches

### DIFF
--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -432,20 +432,25 @@ int Main(int argc, char** argv)
 	{
 		std::set<std::string> uniqueChangeListNumbers;
 		std::set<std::string> notUniqueChangeListNumbers;
-		for (const ChangeList& cl : changes)
+		std::vector<int> markForRemove;
+		for (int i = 0; i < changes.size(); ++i)
 		{
+			ChangeList& cl = changes.at(i);
 			if (!uniqueChangeListNumbers.insert(cl.number).second)
 			{
 				notUniqueChangeListNumbers.insert(cl.number);
+				markForRemove.push_back(i);
 			}
 		}
 		if (!notUniqueChangeListNumbers.empty())
 		{
 			WARN("Changelists appear in more than one branch! These will appear in each branch.");
 			for (const auto& cl : notUniqueChangeListNumbers)
-			{
 				WARN("Duplicate changelist: " << cl);
-			}
+
+			// Remove duplicates
+			for (int i = markForRemove.size() - 1; i >= 0; --i)
+			    changes.erase(changes.begin() + markForRemove[i]);
 		}
 	}
 

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -561,7 +561,7 @@ int Main(int argc, char** argv)
 				mergeFrom = branchGroup.sourceBranch;
 			}
 
-			std::string depotPathString = depotPathString.substr(0, depotPathString.size() - 3);
+			std::string depotPathString = depotPath.substr(0, depotPath.size() - 3);
 			if (branchSet.HasMergeableBranch())
 			{
 				depotPathString += branchGroup.depotBranchPath;

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -354,14 +354,16 @@ int Main(int argc, char** argv)
 	std::string resumeFromCL;
 	if (git.IsHEADExists())
 	{
+		std::string lastCommitDepotPath = git.GetDepotPathFromLastCommit();
+		std::string depotPathWithoutDots = depotPath.substr(0, depotPath.size() - 3);
 		if (branchSet.HasMergeableBranch())
 		{
 			bool foundMatchingBranch = false;
 			for (const Branch& branch : branchSet.GetBranches())
 			{
-				const std::string branchDepotPath = depotPath.substr(0, depotPath.size() - 3) + branch.depotBranchPath;
+				const std::string branchDepotPath = depotPathWithoutDots + branch.depotBranchPath;
 
-				if (git.GetDepotPathFromLastCommit() == branchDepotPath)
+				if (lastCommitDepotPath == branchDepotPath)
 				{
 					foundMatchingBranch = true;
 					break;
@@ -375,7 +377,7 @@ int Main(int argc, char** argv)
 		}
 		else
 		{
-			if (git.GetDepotPathFromLastCommit() + "..." != depotPath)
+			if (lastCommitDepotPath != depotPathWithoutDots)
 			{
 				ERR("Git repository at " << srcPath << " was not initially cloned with depotPath = \"" << depotPath << "\". Exiting.");
 				return 1;
@@ -559,14 +561,10 @@ int Main(int argc, char** argv)
 				mergeFrom = branchGroup.sourceBranch;
 			}
 
-			std::string depotPathString = branchSet.HasMergeableBranch() ? branchGroup.depotBranchPath : depotPath;
-			if (STDHelpers::EndsWith(depotPathString, "/..."))
+			std::string depotPathString = depotPathString.substr(0, depotPathString.size() - 3);
+			if (branchSet.HasMergeableBranch())
 			{
-				depotPathString = depotPathString.substr(0, depotPathString.size() - 3);
-			}
-			if (!STDHelpers::StartsWith(depotPathString, "//"))
-			{
-				depotPathString = "//" + depotPathString;
+				depotPathString += branchGroup.depotBranchPath;
 			}
 
 			std::string commitSHA = git.Commit(depotPathString,

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -354,8 +354,8 @@ int Main(int argc, char** argv)
 	std::string resumeFromCL;
 	if (git.IsHEADExists())
 	{
-		std::string lastCommitDepotPath = git.GetDepotPathFromLastCommit();
-		std::string depotPathWithoutDots = depotPath.substr(0, depotPath.size() - 3);
+		const std::string lastCommitDepotPath = git.GetDepotPathFromLastCommit();
+		const std::string depotPathWithoutDots = depotPath.substr(0, depotPath.size() - 3);
 		if (branchSet.HasMergeableBranch())
 		{
 			bool foundMatchingBranch = false;


### PR DESCRIPTION
When p4-fusion run repeated with `--branch` option, then error come:
`was not initially cloned with any provided branches. Exiting.`

It's caused an error: with `--branch` option the commit message filled with wrong perforce branch path and the second run didn't found the last commit matching branches.