### PR TITLE
build: move aws sdk to a submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Build binaries
 build/
 helix-core-api/
-aws-sdk/
 
 # Misc.
 .DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "vendor/libgit2"]
 	path = vendor/libgit2
 	url = https://github.com/libgit2/libgit2.git
+[submodule "vendor/aws-sdk-cpp"]
+	path = vendor/aws-sdk-cpp
+	url = ../../aws/aws-sdk-cpp

--- a/p4-fusion/CMakeLists.txt
+++ b/p4-fusion/CMakeLists.txt
@@ -48,48 +48,9 @@ endif(APPLE)
 message(${OPENSSL_SSL_LIBRARIES})
 message(${OPENSSL_CRYPTO_LIBRARIES})
 
-include(ExternalProject)
-
-ExternalProject_Add(aws-sdk
-    GIT_REPOSITORY    https://github.com/aws/aws-sdk-cpp.git
-    GIT_TAG           1.11.640
-    CMAKE_ARGS        -DBUILD_SHARED_LIBS=OFF
-                      -DAUTORUN_UNIT_TESTS=OFF
-                      -DBUILD_ONLY=s3
-                      -DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/vendor/aws-sdk
-    PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/aws-sdk
-    BUILD_ALWAYS      TRUE
-    TEST_COMMAND      ""
-)
-
-add_dependencies(p4-fusion aws-sdk)
-
-target_include_directories(p4-fusion PUBLIC
-    ../vendor/aws-sdk/include
-)
-
-target_link_directories(p4-fusion PUBLIC
-    ../vendor/aws-sdk/lib
-)
-
-set(AWSSDK_LINK_LIBRARIES
-    libaws-c-auth.a
-    libaws-c-cal.a
-    libaws-c-common.a
-    libaws-c-compression.a
-    libaws-c-event-stream.a
-    libaws-c-http.a
-    libaws-c-io.a
-    libaws-c-mqtt.a
-    libaws-c-s3.a
-    libaws-c-sdkutils.a
-    libaws-checksums.a
-    libaws-cpp-sdk-core.a
-    libaws-cpp-sdk-s3.a
-    libaws-crt-cpp.a
-)
-
 target_link_libraries(p4-fusion PUBLIC
+    aws-cpp-sdk-core
+    aws-cpp-sdk-s3
     ${Frameworks}
     client
     rpc
@@ -99,13 +60,6 @@ target_link_libraries(p4-fusion PUBLIC
     ${OPENSSL_CRYPTO_LIBRARIES}
     ${CURL_LIBRARIES}
     ${ZLIB_LIBRARIES}
-    ${AWSSDK_LINK_LIBRARIES}
     libgit2package
     minitrace
-)
-
-add_custom_target(deepclean
-    COMMAND ${CMAKE_COMMAND} -E rm -rf ${CMAKE_SOURCE_DIR}/build
-    COMMAND ${CMAKE_COMMAND} -E rm -rf ${CMAKE_SOURCE_DIR}/vendor/aws-sdk
-    COMMENT "Removing AWS SDK on clean"
 )

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -1,3 +1,8 @@
 add_subdirectory(libgit2)
+
+set(BUILD_ONLY "core;s3" CACHE STRING "Filter build" FORCE)
+set(ENABLE_TESTING OFF CACHE BOOL "Disable AWS SDK tests" FORCE)
+add_subdirectory(aws-sdk-cpp)
+
 add_subdirectory(minitrace)
 set_target_properties(minitrace PROPERTIES C_STANDARD 99)


### PR DESCRIPTION
workaround for local build failing due to antivirus
positive side effect: clean builds will be faster, because aws-cpp-sdk will live in `vendors` instead of the build directory.

ACP-24728