### PR TITLE
Allow changelist in multiple branch

### DIFF
--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -439,10 +439,10 @@ int Main(int argc, char** argv)
 		}
 		if (!notUniqueChangeListNumbers.empty())
 		{
-			ERR("Changelists appear more than once. Exiting.");
+			WARN("Changelists appear in more than one branch! These will appear in each branch.");
 			for (const auto& cl : notUniqueChangeListNumbers)
 			{
-				ERR("Duplicate changelist: " << cl);
+				WARN("Duplicate changelist: " << cl);
 			}
 		}
 	}

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -430,8 +430,8 @@ int Main(int argc, char** argv)
 	{
 		std::set<std::string> uniqueChangeListNumbers;
 		std::set<std::string> notUniqueChangeListNumbers;
-		std::vector<int> markForRemove;
-		for (int i = 0; i < changes.size(); ++i)
+		std::vector<size_t> markForRemove;
+		for (size_t i = 0; i < changes.size(); ++i)
 		{
 			ChangeList& cl = changes.at(i);
 			if (!uniqueChangeListNumbers.insert(cl.number).second)
@@ -447,8 +447,8 @@ int Main(int argc, char** argv)
 				WARN("Duplicate changelist: " << cl);
 
 			// Remove duplicates
-			for (int i = markForRemove.size() - 1; i >= 0; --i)
-			    changes.erase(changes.begin() + markForRemove[i]);
+			for (size_t i = markForRemove.size(); i > 0; --i)
+			    changes.erase(changes.begin() + markForRemove[i - 1]);
 		}
 	}
 

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -448,7 +448,7 @@ int Main(int argc, char** argv)
 
 			// Remove duplicates
 			for (size_t i = markForRemove.size(); i > 0; --i)
-			    changes.erase(changes.begin() + markForRemove[i - 1]);
+				changes.erase(changes.begin() + markForRemove[i - 1]);
 		}
 	}
 

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -426,7 +426,7 @@ int Main(int argc, char** argv)
 		}
 	}
 
-	// Check if all changelists appear only once
+	// Detect and log changelists that appear more than once across branches
 	{
 		std::set<std::string> uniqueChangeListNumbers;
 		std::set<std::string> notUniqueChangeListNumbers;

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -430,20 +430,25 @@ int Main(int argc, char** argv)
 	{
 		std::set<std::string> uniqueChangeListNumbers;
 		std::set<std::string> notUniqueChangeListNumbers;
-		for (const ChangeList& cl : changes)
+		std::vector<int> markForRemove;
+		for (int i = 0; i < changes.size(); ++i)
 		{
+			ChangeList& cl = changes.at(i);
 			if (!uniqueChangeListNumbers.insert(cl.number).second)
 			{
 				notUniqueChangeListNumbers.insert(cl.number);
+				markForRemove.push_back(i);
 			}
 		}
 		if (!notUniqueChangeListNumbers.empty())
 		{
 			WARN("Changelists appear in more than one branch! These will appear in each branch.");
 			for (const auto& cl : notUniqueChangeListNumbers)
-			{
 				WARN("Duplicate changelist: " << cl);
-			}
+
+			// Remove duplicates
+			for (int i = markForRemove.size() - 1; i >= 0; --i)
+			    changes.erase(changes.begin() + markForRemove[i]);
 		}
 	}
 

--- a/p4-fusion/main.cc
+++ b/p4-fusion/main.cc
@@ -427,15 +427,24 @@ int Main(int argc, char** argv)
 	}
 
 	// Check if all changelists appear only once
-	std::set<std::string> uniqueChangeListNumbers;
-	for (const ChangeList& cl : changes)
 	{
-		uniqueChangeListNumbers.insert(cl.number);
-	}
-	if (uniqueChangeListNumbers.size() != changes.size())
-	{
-		ERR("Changelists appear more than once. Exiting.");
-		return 1;
+		std::set<std::string> uniqueChangeListNumbers;
+		std::set<std::string> notUniqueChangeListNumbers;
+		for (const ChangeList& cl : changes)
+		{
+			if (!uniqueChangeListNumbers.insert(cl.number).second)
+			{
+				notUniqueChangeListNumbers.insert(cl.number);
+			}
+		}
+		if (!notUniqueChangeListNumbers.empty())
+		{
+			ERR("Changelists appear more than once. Exiting.");
+			for (const auto& cl : notUniqueChangeListNumbers)
+			{
+				ERR("Duplicate changelist: " << cl);
+			}
+		}
 	}
 
 	// Return early if we have no work to do


### PR DESCRIPTION
This fix allows p4-fusion to run when a Perforce changelist touches multiple branches, based on the --branch setup.