### PR TITLE
Crash after perforce reinitialize

### DIFF
--- a/p4-fusion/commands/result.cc
+++ b/p4-fusion/commands/result.cc
@@ -7,8 +7,8 @@
 #include "result.h"
 
 Result::Result(Result&& other) noexcept
-	: ClientUser()
-	, m_Error(other.m_Error)
+    : ClientUser()
+    , m_Error(other.m_Error)
 {
 }
 

--- a/p4-fusion/commands/result.cc
+++ b/p4-fusion/commands/result.cc
@@ -5,10 +5,11 @@
  * For full license text, see the LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 #include "result.h"
+#include <utility>
 
 Result::Result(Result&& other) noexcept
     : ClientUser()
-    , m_Error(other.m_Error)
+    , m_Error(std::move(other.m_Error))
 {
 }
 
@@ -16,7 +17,7 @@ Result& Result::operator=(Result&& other) noexcept
 {
 	if (this != &other)
 	{
-		m_Error = other.m_Error;
+		m_Error = std::move(other.m_Error);
 	}
 	return *this;
 }

--- a/p4-fusion/commands/result.cc
+++ b/p4-fusion/commands/result.cc
@@ -6,9 +6,9 @@
  */
 #include "result.h"
 
-Result::Result(Result&& other) noexcept :
-	ClientUser(),
-	m_Error(other.m_Error)
+Result::Result(Result&& other) noexcept
+	: ClientUser()
+	, m_Error(other.m_Error)
 {
 }
 

--- a/p4-fusion/commands/result.cc
+++ b/p4-fusion/commands/result.cc
@@ -6,6 +6,21 @@
  */
 #include "result.h"
 
+Result::Result(Result&& other) noexcept :
+	ClientUser(),
+	m_Error(other.m_Error)
+{
+}
+
+Result& Result::operator=(Result&& other) noexcept
+{
+	if (this != &other)
+	{
+		m_Error = other.m_Error;
+	}
+	return *this;
+}
+
 void Result::HandleError(Error* e)
 {
 	StrBuf str;

--- a/p4-fusion/commands/result.h
+++ b/p4-fusion/commands/result.h
@@ -13,6 +13,30 @@ class Result : public ClientUser
 	Error m_Error;
 
 public:
+	Result() = default;
+	~Result() override = default;
+
+	// ClientUser contains a std::mutex which is neither copyable nor movable.
+	// Move operations default-construct a fresh ClientUser base and transfer
+	// only Result-level data.  The ClientUser state is only needed during
+	// ClientApi::Run() and is not required after the command completes.
+	Result(Result&& other) noexcept
+	    : ClientUser()
+	    , m_Error(other.m_Error)
+	{
+	}
+	Result& operator=(Result&& other) noexcept
+	{
+		if (this != &other)
+		{
+			m_Error = other.m_Error;
+		}
+		return *this;
+	}
+
+	Result(const Result&) = delete;
+	Result& operator=(const Result&) = delete;
+
 	void HandleError(Error* e) override;
 
 	const Error& GetError() const { return m_Error; }

--- a/p4-fusion/commands/result.h
+++ b/p4-fusion/commands/result.h
@@ -17,6 +17,9 @@ public:
 	~Result() override = default;
 
 	// ClientUser base class contains a std::mutex which is neither copyable nor movable.
+	// Move operations default-construct a fresh ClientUser base and transfer
+	// only Result-level data. The ClientUser state is only needed during
+	// ClientApi::Run() and is not required after the command completes.
 	Result(const Result&) = delete;
 	Result& operator=(const Result&) = delete;
 	Result(Result&& other) noexcept;

--- a/p4-fusion/commands/result.h
+++ b/p4-fusion/commands/result.h
@@ -16,26 +16,11 @@ public:
 	Result() = default;
 	~Result() override = default;
 
-	// ClientUser contains a std::mutex which is neither copyable nor movable.
-	// Move operations default-construct a fresh ClientUser base and transfer
-	// only Result-level data.  The ClientUser state is only needed during
-	// ClientApi::Run() and is not required after the command completes.
-	Result(Result&& other) noexcept
-	    : ClientUser()
-	    , m_Error(other.m_Error)
-	{
-	}
-	Result& operator=(Result&& other) noexcept
-	{
-		if (this != &other)
-		{
-			m_Error = other.m_Error;
-		}
-		return *this;
-	}
-
+	// ClientUser base class contains a std::mutex which is neither copyable nor movable.
 	Result(const Result&) = delete;
 	Result& operator=(const Result&) = delete;
+	Result(Result&& other) noexcept;
+	Result& operator=(Result&& other) noexcept;
 
 	void HandleError(Error* e) override;
 


### PR DESCRIPTION
After a perforce connection broken, the reconnection crashed. This caused by a std::mutex copy. I didn't submerge in the class hierarchy and didn't refactoring it, I just handle the invalid copy with move constructor and assignment operator.

Copilot was he solve this mystery ;)