### PR TITLE
Fix release tagging issue in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,6 @@ jobs:
     - uses: actions/checkout@v6
       with:
         submodules: true
-        fetch-depth: 0
         # Build the actual PR head, not the synthetic merge commit, so the
         # binary and the release tag both point at the current branch.
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -39,7 +38,7 @@ jobs:
         TARGET_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       run: |
         set -euo pipefail
-        VERSION="v$(date -u +%Y%m%d).r$(git rev-list --count HEAD)"
+        VERSION="v$(date -u +%Y%m%d).r${{ github.run_number }}"
 
         if [ "$BRANCH" = "$DEFAULT_BRANCH" ]; then
           IS_PRERELEASE=false

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
           IS_PRERELEASE=false
           IS_LATEST=true
         else
-          VERSION="$VERSION-$(echo "$BRANCH" | tr -c 'A-Za-z0-9.-' '-')"
+          VERSION="$VERSION-$(echo -n "$BRANCH" | tr -c 'A-Za-z0-9.-' '-')"
           IS_PRERELEASE=true
           IS_LATEST=false
         fi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,12 +35,13 @@ jobs:
       id: version
       env:
         BRANCH: ${{ github.head_ref || github.ref_name }}
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         TARGET_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       run: |
         set -euo pipefail
         VERSION="v$(date -u +%Y%m%d).r$(git rev-list --count HEAD)"
 
-        if [ "$BRANCH" = "gs-specific" ]; then
+        if [ "$BRANCH" = "$DEFAULT_BRANCH" ]; then
           IS_PRERELEASE=false
           IS_LATEST=true
         else

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ jobs:
           IS_PRERELEASE=false
           IS_LATEST=true
         else
-          VERSION="$VERSION-$(echo "$BRANCH" | tr '/' '-')"
+          VERSION="$VERSION-$(echo "$BRANCH" | tr -c 'A-Za-z0-9.-' '-')"
           IS_PRERELEASE=true
           IS_LATEST=false
         fi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,23 +3,13 @@ name: build-check
 on:
   pull_request:
   push:
-    branches: [gs-specific]
+    branches:
+      - gs-specific
   workflow_dispatch:
-    inputs:
-      release_type:
-        description: "What to publish"
-        type: choice
-        required: true
-        default: prerelease
-        options: [none, prerelease, release]
-      mark_as_latest:
-        description: "Mark as latest release (only for release_type=release)"
-        type: boolean
-        default: false
 
 jobs:
   macos:
-    runs-on: macos-latest
+    runs-on: "macos-latest"
 
     steps:
     - uses: actions/checkout@v6
@@ -27,11 +17,12 @@ jobs:
         submodules: true
         fetch-depth: 0
         # Build the actual PR head, not the synthetic merge commit, so the
-        # binary and the release tag both point at the branch under test.
+        # binary and the release tag both point at the current branch.
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-    - name: Install OpenSSL 3
-      run: brew list openssl@3 &>/dev/null || brew install openssl@3
+    - name: Ensure OpenSSL 3 is installed
+      run: |
+        brew list openssl@3 &>/dev/null || brew install openssl@3
 
     - name: Download Helix Core C++ API
       run: |
@@ -40,95 +31,67 @@ jobs:
         tar -C vendor/helix-core-api/mac -xzf p4api-openssl3.tgz --strip 1
         rm p4api-openssl3.tgz
 
-    - name: Resolve release parameters
-      id: release
+    - name: Determine version
+      id: version
       env:
-        EVENT: ${{ github.event_name }}
-        REF_TYPE: ${{ github.ref_type }}
-        REF_NAME: ${{ github.ref_name }}
         BRANCH: ${{ github.head_ref || github.ref_name }}
         TARGET_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-        DISPATCH_TYPE: ${{ github.event.inputs.release_type }}
-        DISPATCH_LATEST: ${{ github.event.inputs.mark_as_latest }}
       run: |
         set -euo pipefail
+        CALVER="v$(date -u +%Y%m%d).r$(git rev-list --count HEAD)"
 
-        publish=true
-        prerelease=true
-        latest=false
-
-        if [ "$REF_TYPE" = "tag" ]; then
-          version="$REF_NAME"
-          prerelease=false
-          latest=true
+        if [ "$BRANCH" = "gs-specific" ]; then
+          VERSION="$CALVER"
+          IS_PRERELEASE=false
+          IS_LATEST=true
         else
-          calver="$(date -u +%Y%m%d).r$(git rev-list --count HEAD)"
-
-          case "$EVENT" in
-            workflow_dispatch)
-              case "$DISPATCH_TYPE" in
-                none)     publish=false ;;
-                release)  prerelease=false; latest="$DISPATCH_LATEST" ;;
-                *)        prerelease=true ;;
-              esac
-              ;;
-            push)
-              # Only configured branch reaching this job is gs-specific.
-              prerelease=false
-              latest=true
-              ;;
-          esac
-
-          if [ "$prerelease" = "true" ]; then
-            version="v${calver}-$(echo "$BRANCH" | tr '/' '-')"
-          else
-            version="v${calver}"
-          fi
+          VERSION="$CALVER-$(echo "$BRANCH" | tr '/' '-')"
+          IS_PRERELEASE=true
+          IS_LATEST=false
         fi
 
         {
-          echo "version=$version"
-          echo "publish=$publish"
-          echo "prerelease=$prerelease"
-          echo "latest=$latest"
+          echo "version=$VERSION"
+          echo "is_prerelease=$IS_PRERELEASE"
+          echo "is_latest=$IS_LATEST"
           echo "target_sha=$TARGET_SHA"
         } >> "$GITHUB_OUTPUT"
 
     - name: Generate CMake project
-      run: ./generate_cache.sh Release pt
+      run: |
+        ./generate_cache.sh Release pt
 
     - name: Build
-      run: ./build.sh
+      run: |
+        ./build.sh
 
     - name: Smoke test
       run: |
-        otool -L ./build/p4-fusion/p4-fusion
-        ./build/p4-fusion/p4-fusion --help
+        BINARY_PATH="./build/p4-fusion/p4-fusion"
+
+        echo "Dependency check..."
+        otool -L "$BINARY_PATH"
+
+        echo "Help output"
+        "$BINARY_PATH" --help
 
     - name: Test
-      run: ./build/tests/p4-fusion-test
+      run: |
+        ./build/tests/p4-fusion-test
 
     - name: Package binary
       run: |
         mkdir pkg
-        tar -C build/p4-fusion -czf "pkg/p4-fusion-${{ steps.release.outputs.version }}.tar.gz" p4-fusion
-
-    - name: Upload build artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: p4-fusion-${{ steps.release.outputs.version }}
-        path: pkg/p4-fusion-${{ steps.release.outputs.version }}.tar.gz
-        if-no-files-found: error
+        tar -C build/p4-fusion -czf pkg/p4-fusion-${{ steps.version.outputs.version }}.tar.gz p4-fusion
 
     - name: Publish release
-      if: steps.release.outputs.publish == 'true'
       uses: softprops/action-gh-release@v3
       with:
-        tag_name: ${{ steps.release.outputs.version }}
-        target_commitish: ${{ steps.release.outputs.target_sha }}
-        files: pkg/p4-fusion-${{ steps.release.outputs.version }}.tar.gz
-        prerelease: ${{ steps.release.outputs.prerelease }}
-        make_latest: ${{ steps.release.outputs.latest }}
+        tag_name: ${{ steps.version.outputs.version }}
+        target_commitish: ${{ steps.version.outputs.target_sha }}
+        files: pkg/p4-fusion-${{ steps.version.outputs.version }}.tar.gz
+        prerelease: ${{ steps.version.outputs.is_prerelease }}
+        make_latest: ${{ steps.version.outputs.is_latest }}
         generate_release_notes: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,21 +2,36 @@ name: build-check
 
 on:
   pull_request:
+  push:
+    branches: [gs-specific]
   workflow_dispatch:
+    inputs:
+      release_type:
+        description: "What to publish"
+        type: choice
+        required: true
+        default: prerelease
+        options: [none, prerelease, release]
+      mark_as_latest:
+        description: "Mark as latest release (only for release_type=release)"
+        type: boolean
+        default: false
 
 jobs:
   macos:
-    runs-on: "macos-latest"
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v6
       with:
         submodules: true
         fetch-depth: 0
+        # Build the actual PR head, not the synthetic merge commit, so the
+        # binary and the release tag both point at the branch under test.
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-    - name: Ensure OpenSSL 3 is installed
-      run: |
-        brew list openssl@3 &>/dev/null || brew install openssl@3
+    - name: Install OpenSSL 3
+      run: brew list openssl@3 &>/dev/null || brew install openssl@3
 
     - name: Download Helix Core C++ API
       run: |
@@ -25,64 +40,95 @@ jobs:
         tar -C vendor/helix-core-api/mac -xzf p4api-openssl3.tgz --strip 1
         rm p4api-openssl3.tgz
 
-    - name: Determine version
-      id: version
+    - name: Resolve release parameters
+      id: release
+      env:
+        EVENT: ${{ github.event_name }}
+        REF_TYPE: ${{ github.ref_type }}
+        REF_NAME: ${{ github.ref_name }}
+        BRANCH: ${{ github.head_ref || github.ref_name }}
+        TARGET_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        DISPATCH_TYPE: ${{ github.event.inputs.release_type }}
+        DISPATCH_LATEST: ${{ github.event.inputs.mark_as_latest }}
       run: |
-        if [ "${{ github.ref_type }}" = "tag" ]; then  # Tagged release
-          echo "version=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
-          echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
-        else
-          CALVER="$(date -u +%Y%m%d).r$(git rev-list --count HEAD)"
-          
-          if [ -n "${{ github.head_ref }}" ]; then
-            BRANCH_NAME="${{ github.head_ref }}"
-          else
-            BRANCH_NAME="${{ github.ref_name }}"
-          fi
+        set -euo pipefail
 
-          if [ "$BRANCH_NAME" = "main" ]; then  # main branch release
-            echo "version=v${CALVER}" >> "$GITHUB_OUTPUT"
-            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+        publish=true
+        prerelease=true
+        latest=false
+
+        if [ "$REF_TYPE" = "tag" ]; then
+          version="$REF_NAME"
+          prerelease=false
+          latest=true
+        else
+          calver="$(date -u +%Y%m%d).r$(git rev-list --count HEAD)"
+
+          case "$EVENT" in
+            workflow_dispatch)
+              case "$DISPATCH_TYPE" in
+                none)     publish=false ;;
+                release)  prerelease=false; latest="$DISPATCH_LATEST" ;;
+                *)        prerelease=true ;;
+              esac
+              ;;
+            push)
+              # Only configured branch reaching this job is gs-specific.
+              prerelease=false
+              latest=true
+              ;;
+          esac
+
+          if [ "$prerelease" = "true" ]; then
+            version="v${calver}-$(echo "$BRANCH" | tr '/' '-')"
           else
-            SAFE_BRANCH=$(echo "$BRANCH_NAME" | tr '/' '-')  # prerelease
-            echo "version=v${CALVER}-${SAFE_BRANCH}" >> "$GITHUB_OUTPUT"
-            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+            version="v${calver}"
           fi
         fi
 
+        {
+          echo "version=$version"
+          echo "publish=$publish"
+          echo "prerelease=$prerelease"
+          echo "latest=$latest"
+          echo "target_sha=$TARGET_SHA"
+        } >> "$GITHUB_OUTPUT"
+
     - name: Generate CMake project
-      run: |
-        ./generate_cache.sh Release pt
+      run: ./generate_cache.sh Release pt
 
     - name: Build
-      run: |
-        ./build.sh
+      run: ./build.sh
 
     - name: Smoke test
       run: |
-        BINARY_PATH="./build/p4-fusion/p4-fusion"
-
-        echo "Dependency check..."
-        otool -L "$BINARY_PATH"
-
-        echo "Help output"
-        "$BINARY_PATH" --help
+        otool -L ./build/p4-fusion/p4-fusion
+        ./build/p4-fusion/p4-fusion --help
 
     - name: Test
-      run: |
-          ./build/tests/p4-fusion-test
+      run: ./build/tests/p4-fusion-test
 
     - name: Package binary
       run: |
         mkdir pkg
-        tar -C build/p4-fusion -czf pkg/p4-fusion-${{ steps.version.outputs.version }}.tar.gz p4-fusion
+        tar -C build/p4-fusion -czf "pkg/p4-fusion-${{ steps.release.outputs.version }}.tar.gz" p4-fusion
+
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: p4-fusion-${{ steps.release.outputs.version }}
+        path: pkg/p4-fusion-${{ steps.release.outputs.version }}.tar.gz
+        if-no-files-found: error
 
     - name: Publish release
+      if: steps.release.outputs.publish == 'true'
       uses: softprops/action-gh-release@v3
       with:
-        tag_name: ${{ steps.version.outputs.version }}
-        files: pkg/p4-fusion-${{ steps.version.outputs.version }}.tar.gz
-        prerelease: ${{ steps.version.outputs.is_prerelease }}
+        tag_name: ${{ steps.release.outputs.version }}
+        target_commitish: ${{ steps.release.outputs.target_sha }}
+        files: pkg/p4-fusion-${{ steps.release.outputs.version }}.tar.gz
+        prerelease: ${{ steps.release.outputs.prerelease }}
+        make_latest: ${{ steps.release.outputs.latest }}
         generate_release_notes: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,9 +15,6 @@ jobs:
     - uses: actions/checkout@v6
       with:
         submodules: true
-        # Build the actual PR head, not the synthetic merge commit, so the
-        # binary and the release tag both point at the current branch.
-        ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
     - name: Ensure OpenSSL 3 is installed
       run: |
@@ -35,7 +32,7 @@ jobs:
       env:
         BRANCH: ${{ github.head_ref || github.ref_name }}
         DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-        TARGET_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        TARGET_SHA: ${{ github.event.pull_request.head.sha || github.sha }}  # the actual PR head, not the synthetic merge commit
       run: |
         set -euo pipefail
         VERSION="v$(date -u +%Y%m%d).r${{ github.run_number }}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,14 +38,13 @@ jobs:
         TARGET_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       run: |
         set -euo pipefail
-        CALVER="v$(date -u +%Y%m%d).r$(git rev-list --count HEAD)"
+        VERSION="v$(date -u +%Y%m%d).r$(git rev-list --count HEAD)"
 
         if [ "$BRANCH" = "gs-specific" ]; then
-          VERSION="$CALVER"
           IS_PRERELEASE=false
           IS_LATEST=true
         else
-          VERSION="$CALVER-$(echo "$BRANCH" | tr '/' '-')"
+          VERSION="$VERSION-$(echo "$BRANCH" | tr '/' '-')"
           IS_PRERELEASE=true
           IS_LATEST=false
         fi


### PR DESCRIPTION
Fixed an issue, where a workflow run would incorrectly tag the default branch's latest commit instead of the actual state of the current branch. Now the release's tag correctly points to the state it was built from.

Further Improvements:
- Fixed an issue, where a full release would be made automatically on the branch 'main'. This branch does not exist. Instead, we now create a release, set as latest when pushing to 'gs-specific' (so after merging a pr, or a direct push)
- Formatting: Removed some whitespace in the 'Test' step. 